### PR TITLE
Fixes for claims plugin

### DIFF
--- a/plugins/claims.py
+++ b/plugins/claims.py
@@ -117,6 +117,8 @@ class Claims(StorageCommandPlugin):
             send_message(connection, "This planet is not protected.")
         elif not self.is_owner(alias, location):
             send_message(connection, "You don't own this planet!")
+        elif location.locationtype() is "ShipWorld":
+            send_message(connection, "Can't unclaim your ship!")
         else:
             self.storage["owners"][alias].remove(str(location))
             if len(self.storage["owners"][alias]) == 0:
@@ -203,6 +205,9 @@ class Claims(StorageCommandPlugin):
         if target is not None:
             if not self.is_owner(alias, location):
                 send_message(connection, "You don't own this planet!")
+            elif location.locationtype() is "ShipWorld":
+                send_message(connection, "Can't transfer ownership of your "
+                                         "ship!")
             elif 'Registered' not in target.roles:
                 send_message(connection, "Target is not high enough rank to "
                                          "own a planet!")

--- a/plugins/claims.py
+++ b/plugins/claims.py
@@ -80,6 +80,28 @@ class Claims(StorageCommandPlugin):
         except AttributeError:
             pass
 
+    def _pretty_world_name(self, location):
+        """
+        Returns a more nicely formatted version of a raw world name.
+        Currently only works with CelestialWorld names.
+
+        :param location: String: The name to be formatted.
+        :return: String: A formatted version of the name.
+        """
+        loc = location.split(":")
+        if loc.pop(0) != "CelestialWorld":
+            return location
+        else:
+            print(loc)
+            loc[0] = "X: " + loc[0]
+            loc[1] = "Y: " + loc[1]
+            print(loc)
+            loc.remove(loc[2])
+            print(loc)
+            if loc[3] is "0":
+                loc.remove(loc[3])
+            return " ".join(loc)
+
     @Command("claim",
              role=Registered,
              doc="Claim a planet to be protected.")
@@ -240,4 +262,4 @@ class Claims(StorageCommandPlugin):
         alias = connection.player.alias
         send_message(connection, "You've claimed the following worlds:")
         for location in self.storage["owners"][alias]:
-            send_message(connection, location)
+            send_message(connection, self._pretty_world_name(location))

--- a/plugins/claims.py
+++ b/plugins/claims.py
@@ -91,19 +91,16 @@ class Claims(StorageCommandPlugin):
         elif alias not in self.storage["owners"]:
             self.storage["owners"][alias] = []
             self.storage["owners"][alias].append(str(location))
-            print(self.storage["owners"][alias])
             self.planet_protect.add_protection(location, connection.player)
             send_message(connection, "Successfully claimed planet {}."
                          .format(location))
         else:
             if len(self.storage["owners"][alias]) >= self.max_claims:
-                print(self.storage["owners"][alias])
                 send_message(connection, "You have reached the maximum "
                                          "number of claimed planets.")
             else:
                 self.storage["owners"][alias].append(str(location))
                 self.planet_protect.add_protection(location, connection.player)
-                print(self.storage["owners"][alias])
                 send_message(connection, "Successfully claimed planet {}."
                              .format(location))
 
@@ -153,7 +150,7 @@ class Claims(StorageCommandPlugin):
                                  .format(target.alias))
         else:
             send_message(connection, "Player {} could not be found."
-                         .format(target.alias))
+                         .format(" ".join(data)))
 
     @Command("rm_helper",
              role=Registered,
@@ -176,7 +173,7 @@ class Claims(StorageCommandPlugin):
                              .format(target.alias, location))
         else:
             send_message(connection, "Player {} could not be found."
-                         .format(target.alias))
+                         .format(" ".join(data)))
 
     @Command("helper_list",
              role=Registered,
@@ -234,4 +231,13 @@ class Claims(StorageCommandPlugin):
                                  .format(target.alias))
         else:
             send_message(connection, "Player {} could not be found."
-                         .format(target))
+                         .format(" ".join(data)))
+
+    @Command("list_claims",
+             role=Registered,
+             doc="List all of the planets you've claimed.")
+    def _list_claims(self, data, connection):
+        alias = connection.player.alias
+        send_message(connection, "You've claimed the following worlds:")
+        for location in self.storage["owners"][alias]:
+            send_message(connection, location)

--- a/plugins/claims.py
+++ b/plugins/claims.py
@@ -141,6 +141,8 @@ class Claims(StorageCommandPlugin):
                 protection = self.planet_protect.get_protection(location)
                 protection.add_builder(target)
                 try:
+                    send_message(connection, "Granted build access to player"
+                                             " {}.".format(target.alias))
                     yield from send_message(target.connection, "You've been "
                                                                "granted build "
                                                                "access on {}."

--- a/plugins/claims.py
+++ b/plugins/claims.py
@@ -28,6 +28,7 @@ class Claims(StorageCommandPlugin):
         super().activate()
         if "owners" not in self.storage:
             self.storage["owners"] = {}
+        # noinspection PyUnresolvedReferences
         self.max_claims = self.config.get_plugin_config(self.name)[
             "max_claims_per_person"]
 
@@ -80,6 +81,7 @@ class Claims(StorageCommandPlugin):
         except AttributeError:
             pass
 
+    # noinspection PyMethodMayBeStatic
     def _pretty_world_name(self, location):
         """
         Returns a more nicely formatted version of a raw world name.
@@ -92,12 +94,9 @@ class Claims(StorageCommandPlugin):
         if loc.pop(0) != "CelestialWorld":
             return location
         else:
-            print(loc)
             loc[0] = "X: " + loc[0]
             loc[1] = "Y: " + loc[1]
-            print(loc)
             loc.remove(loc[2])
-            print(loc)
             if loc[3] is "0":
                 loc.remove(loc[3])
             return " ".join(loc)
@@ -232,10 +231,14 @@ class Claims(StorageCommandPlugin):
             elif 'Registered' not in target.roles:
                 send_message(connection, "Target is not high enough rank to "
                                          "own a planet!")
-                print(target.roles)
             else:
                 if target.alias not in self.storage["owners"]:
                     self.storage["owners"][target.alias] = []
+                if len(self.storage["owners"][target.alias]) >= \
+                        self.max_claims:
+                    send_message(connection, "The target player has reached "
+                                             "the maximum number of claims!")
+                    return
                 self.storage["owners"][target.alias].append(str(location))
                 self.storage["owners"][alias].remove(str(location))
                 if len(self.storage["owners"][alias]) == 0:


### PR DESCRIPTION
- Disallow unclaiming ShipWorlds
- Feedback when /add_helper successfully adds a player to the build list
- Fix incorrect messages for when a player isn't found by /add_helper, /rm_helper, or /change_owner
- Add a /list_claims command that outputs the coordinates of planets a player has claimed
- Check max claims when transferring ownership of a planet to another player