### PR TITLE
Fix more bugs

### DIFF
--- a/Chat Commands.md
+++ b/Chat Commands.md
@@ -382,10 +382,9 @@ Note: This is old syntax, in that each player has their own spawn planet. It wou
   - Command Dispatcher, Player Manager
   
 - ***Commands Provided***
-  - /warp [from player] (to player)
+  - /tp [from player] (to player)
     - **Role:** Moderator
     - **Description:** Warps the specified from player, or self if none, to the specified to player.
-    - **Alias:** /tp
     
   - /tps [from player] (to player)
     - **Role:** Moderator

--- a/DISCORD_BOT_SETUP.md
+++ b/DISCORD_BOT_SETUP.md
@@ -1,0 +1,29 @@
+# StarryPy Discord Bot
+
+StarryPy includes a plugin that allows you to connect a bot to a Discord 
+server that will relay messages between the Starbound and Discord servers. 
+If the IRC bot also included with StarryPy is enabled, the Discord and IRC 
+plugins will also relay messages between each other.
+
+## Using the Discord Bot
+The Discord bot plugin uses the [discord.py](https://github.com/Rapptz/discord.py)
+library, and will not work without it.
+
+To use the Discord bot, you will need to create a Discord application. Go to 
+[this page](https://discordapp.com/developers/applications/me) and click the
+ "New Application" button.
+ Give your bot a descriptive name; giving it an avatar or description is optional.
+ 
+ Once you have created your application, you must create a bot user by clicking the "Create a Bot User" option on 
+ the application's page.
+ 
+ To add the bot to your server, go to `https://discordapp.com/oauth2/authorize?&client_id=CLIENT_ID&scope=bot&permissions=0`
+ (replacing `CLIENT_ID` with your application's client ID) and add the 
+ bot to your server.
+ 
+ Once the bot is added to your server, copy the token 
+ and client id from the application to the fields in config.json. Get the 
+ channel id for a given channel by enabling Developer Mode in 
+ Discord, right-clicking a channel, and clicking "Copy ID," then paste this 
+ ID into the "channel" field in config.json. Your bot should now be fully 
+ configured and ready to use.

--- a/OPTIONAL_REQUIREMENTS
+++ b/OPTIONAL_REQUIREMENTS
@@ -1,2 +1,2 @@
-tornado
 irc3
+discord.py

--- a/plugins/chat_enhancements.py
+++ b/plugins/chat_enhancements.py
@@ -243,7 +243,7 @@ class ChatEnhancements(SimpleCommandPlugin):
         except IndexError:
             raise SyntaxWarning("No target provided.")
 
-        recipient = self.plugins.player_manager.get_player_by_alias(name)
+        recipient = self.plugins.player_manager.find_player(name)
         if recipient is not None:
             if not recipient.logged_in:
                 send_message(connection,

--- a/plugins/chat_manager.py
+++ b/plugins/chat_manager.py
@@ -98,7 +98,7 @@ class ChatManager(SimpleCommandPlugin):
         :return: Null
         """
         alias = " ".join(data)
-        player = self.plugins.player_manager.get_player_by_alias(alias)
+        player = self.plugins.player_manager.find_player(alias)
         if player is None:
             raise NameError
         elif self.mute_check(player):
@@ -131,7 +131,7 @@ class ChatManager(SimpleCommandPlugin):
         :return: Null
         """
         alias = " ".join(data)
-        player = self.plugins.player_manager.get_player_by_alias(alias)
+        player = self.plugins.player_manager.find_player(alias)
         if player is None:
             raise NameError
         elif not self.mute_check(player):

--- a/plugins/claims.py
+++ b/plugins/claims.py
@@ -166,6 +166,8 @@ class Claims(StorageCommandPlugin):
         alias = connection.player.alias
         uuid = connection.player.uuid
         target = self.plugins.player_manager.get_player_by_alias(" ".join(data))
+        if not self.planet_protect.check_protection(location):
+            send_message(connection, "This location is not protected.")
         if target is not None:
             if not self.is_owner(uuid, location):
                 send_message(connection, "You don't own this planet!")
@@ -195,6 +197,8 @@ class Claims(StorageCommandPlugin):
         alias = connection.player.alias
         uuid = connection.player.uuid
         target = self.plugins.player_manager.get_player_by_alias(" ".join(data))
+        if not self.planet_protect.check_protection(location):
+            send_message(connection, "This location is not protected.")
         if target is not None:
             if not self.is_owner(uuid, location):
                 send_message(connection, "You don't own this planet!")
@@ -218,11 +222,9 @@ class Claims(StorageCommandPlugin):
         uuid = connection.player.uuid
         location = connection.player.location
         if not self.planet_protect.check_protection(location):
-            send_message(connection,
-                         "This location is not protected.")
+            send_message(connection, "This location is not protected.")
         elif not self.is_owner(uuid, location):
-            send_message(connection,
-                         "You don't own this planet!")
+            send_message(connection, "You don't own this planet!")
         else:
             protection = self.planet_protect.get_protection(location)
             players = ", ".join(protection.get_builders())
@@ -237,6 +239,8 @@ class Claims(StorageCommandPlugin):
         uuid = connection.player.uuid
         location = connection.player.location
         target = self.plugins.player_manager.get_player_by_alias(" ".join(data))
+        if not self.planet_protect.check_protection(location):
+            send_message(connection, "This location is not protected.")
         if target is not None:
             if not self.is_owner(uuid, location):
                 send_message(connection, "You don't own this planet!")
@@ -279,6 +283,9 @@ class Claims(StorageCommandPlugin):
              doc="List all of the planets you've claimed.")
     def _list_claims(self, data, connection):
         uuid = connection.player.uuid
-        send_message(connection, "You've claimed the following worlds:")
-        for location in self.storage["owners"][uuid]:
-            send_message(connection, self._pretty_world_name(location))
+        if self.storage["owners"][uuid]:
+            send_message(connection, "You've claimed the following worlds:")
+            for location in self.storage["owners"][uuid]:
+                send_message(connection, self._pretty_world_name(location))
+        else:
+            send_message(connection, "You haven't claimed any worlds.")

--- a/plugins/claims.py
+++ b/plugins/claims.py
@@ -234,7 +234,6 @@ class Claims(StorageCommandPlugin):
              role=Registered,
              doc="Transfer ownership of the planet to another person.")
     def _change_owner(self, data, connection):
-        alias = connection.player.alias
         uuid = connection.player.uuid
         location = connection.player.location
         target = self.plugins.player_manager.get_player_by_alias(" ".join(data))
@@ -259,6 +258,7 @@ class Claims(StorageCommandPlugin):
                 self.storage["owners"][uuid].remove(str(location))
                 if len(self.storage["owners"][uuid]) == 0:
                     self.storage["owners"].pop(uuid)
+                self.planet_protect.add_protection(location, target)
                 send_message(connection, "Transferred ownership of {} to {}."
                              .format(location, target.alias))
                 try:

--- a/plugins/claims.py
+++ b/plugins/claims.py
@@ -165,7 +165,7 @@ class Claims(StorageCommandPlugin):
         location = connection.player.location
         alias = connection.player.alias
         uuid = connection.player.uuid
-        target = self.plugins.player_manager.get_player_by_alias(" ".join(data))
+        target = self.plugins.player_manager.find_player(" ".join(data))
         if not self.planet_protect.check_protection(location):
             send_message(connection, "This location is not protected.")
         if target is not None:
@@ -196,7 +196,7 @@ class Claims(StorageCommandPlugin):
         location = connection.player.location
         alias = connection.player.alias
         uuid = connection.player.uuid
-        target = self.plugins.player_manager.get_player_by_alias(" ".join(data))
+        target = self.plugins.player_manager.find_player(" ".join(data))
         if not self.planet_protect.check_protection(location):
             send_message(connection, "This location is not protected.")
         if target is not None:
@@ -238,7 +238,7 @@ class Claims(StorageCommandPlugin):
     def _change_owner(self, data, connection):
         uuid = connection.player.uuid
         location = connection.player.location
-        target = self.plugins.player_manager.get_player_by_alias(" ".join(data))
+        target = self.plugins.player_manager.find_player(" ".join(data))
         if not self.planet_protect.check_protection(location):
             send_message(connection, "This location is not protected.")
         if target is not None:

--- a/plugins/claims.py
+++ b/plugins/claims.py
@@ -73,7 +73,7 @@ class Claims(StorageCommandPlugin):
             if connection.player.location.locationtype() is "ShipWorld":
                 ship = connection.player.location
                 uuid = connection.player.uuid
-                if ship.player == uuid:
+                if ship.uuid.decode("utf-8") == uuid:
                     if not self.planet_protect.check_protection(ship):
                         self.planet_protect. add_protection(ship,
                                                             connection.player)

--- a/plugins/claims.py
+++ b/plugins/claims.py
@@ -28,14 +28,23 @@ class Claims(StorageCommandPlugin):
         super().activate()
         if "owners" not in self.storage:
             self.storage["owners"] = {}
-        # noinspection PyUnresolvedReferences
         self.max_claims = self.config.get_plugin_config(self.name)[
             "max_claims_per_person"]
+        # Convert alias entries to uuid entries
+        to_convert = {}
+        for alias in self.storage["owners"].keys():
+            player = self.plugins["player_manager"].get_player_by_alias(alias)
+            if player:
+                to_convert[alias] = player.uuid
+        if to_convert:
+            for alias, uuid in to_convert.items():
+                self.storage["owners"][uuid] = self.storage["owners"].pop(alias)
 
-    def is_owner(self, alias, location):
-        if alias not in self.storage["owners"]:
+
+    def is_owner(self, uuid, location):
+        if uuid not in self.storage["owners"]:
             return False
-        elif str(location) not in self.storage["owners"][alias]:
+        elif str(location) not in self.storage["owners"][uuid]:
             return False
         else:
             return True
@@ -63,21 +72,21 @@ class Claims(StorageCommandPlugin):
         try:
             if connection.player.location.locationtype() is "ShipWorld":
                 ship = connection.player.location
-                alias = connection.player.alias
-                if ship.player == alias:
+                uuid = connection.player.uuid
+                if ship.player == uuid:
                     if not self.planet_protect.check_protection(ship):
                         self.planet_protect. add_protection(ship,
                                                             connection.player)
                         send_message(connection,
                                      "Your ship has been auto-claimed in "
                                      "your name.")
-                        if alias not in self.storage["owners"]:
-                            self.storage["owners"][alias] = []
-                        self.storage["owners"][alias].append(str(ship))
-                    if alias not in self.storage["owners"]:
-                        self.storage["owners"][alias] = [str(ship)]
-                    elif str(ship) not in self.storage["owners"][alias]:
-                        self.storage["owners"][alias].append(str(ship))
+                        if uuid not in self.storage["owners"]:
+                            self.storage["owners"][uuid] = []
+                        self.storage["owners"][uuid].append(str(ship))
+                    if uuid not in self.storage["owners"]:
+                        self.storage["owners"][uuid] = [str(ship)]
+                    elif str(ship) not in self.storage["owners"][uuid]:
+                        self.storage["owners"][uuid].append(str(ship))
         except AttributeError:
             pass
 
@@ -108,23 +117,23 @@ class Claims(StorageCommandPlugin):
              doc="Claim a planet to be protected.")
     def _claim(self, data, connection):
         location = connection.player.location
-        alias = connection.player.alias
+        uuid = connection.player.uuid
         if self.planet_protect.check_protection(location):
             send_message(connection, "This location is already protected.")
         elif not str(location).startswith("CelestialWorld"):
             send_message(connection, "This location cannot be claimed.")
-        elif alias not in self.storage["owners"]:
-            self.storage["owners"][alias] = []
-            self.storage["owners"][alias].append(str(location))
+        elif uuid not in self.storage["owners"]:
+            self.storage["owners"][uuid] = []
+            self.storage["owners"][uuid].append(str(location))
             self.planet_protect.add_protection(location, connection.player)
             send_message(connection, "Successfully claimed planet {}."
                          .format(location))
         else:
-            if len(self.storage["owners"][alias]) >= self.max_claims:
+            if len(self.storage["owners"][uuid]) >= self.max_claims:
                 send_message(connection, "You have reached the maximum "
                                          "number of claimed planets.")
             else:
-                self.storage["owners"][alias].append(str(location))
+                self.storage["owners"][uuid].append(str(location))
                 self.planet_protect.add_protection(location, connection.player)
                 send_message(connection, "Successfully claimed planet {}."
                              .format(location))
@@ -134,17 +143,17 @@ class Claims(StorageCommandPlugin):
              doc="Unclaim and unprotect the planet you're standing on.")
     def _unclaim(self, data, connection):
         location = connection.player.location
-        alias = connection.player.alias
+        uuid = connection.player.uuid
         if not self.planet_protect.check_protection(location):
             send_message(connection, "This planet is not protected.")
-        elif not self.is_owner(alias, location):
+        elif not self.is_owner(uuid, location):
             send_message(connection, "You don't own this planet!")
         elif location.locationtype() is "ShipWorld":
             send_message(connection, "Can't unclaim your ship!")
         else:
-            self.storage["owners"][alias].remove(str(location))
-            if len(self.storage["owners"][alias]) == 0:
-                self.storage["owners"].pop(alias)
+            self.storage["owners"][uuid].remove(str(location))
+            if len(self.storage["owners"][uuid]) == 0:
+                self.storage["owners"].pop(uuid)
             self.planet_protect.disable_protection(location)
             send_message(connection, "Unclaimed planet {} "
                                      "successfully.".format(location))
@@ -155,9 +164,10 @@ class Claims(StorageCommandPlugin):
     def _add_helper(self, data, connection):
         location = connection.player.location
         alias = connection.player.alias
+        uuid = connection.player.uuid
         target = self.plugins.player_manager.get_player_by_alias(" ".join(data))
         if target is not None:
-            if not self.is_owner(alias, location):
+            if not self.is_owner(uuid, location):
                 send_message(connection, "You don't own this planet!")
             else:
                 protection = self.planet_protect.get_protection(location)
@@ -183,9 +193,10 @@ class Claims(StorageCommandPlugin):
     def _rm_helper(self, data, connection):
         location = connection.player.location
         alias = connection.player.alias
+        uuid = connection.player.uuid
         target = self.plugins.player_manager.get_player_by_alias(" ".join(data))
         if target is not None:
-            if not self.is_owner(alias, location):
+            if not self.is_owner(uuid, location):
                 send_message(connection, "You don't own this planet!")
             elif str.lower(target.alias) == str.lower(alias):
                 send_message(connection, "Can't remove yourself from the build"
@@ -204,12 +215,12 @@ class Claims(StorageCommandPlugin):
              role=Registered,
              doc="List all of the people allowed to build on this planet.")
     def _helper_list(self, data, connection):
-        alias = connection.player.alias
+        uuid = connection.player.uuid
         location = connection.player.location
         if not self.planet_protect.check_protection(location):
             send_message(connection,
                          "This location is not protected.")
-        elif not self.is_owner(alias, location):
+        elif not self.is_owner(uuid, location):
             send_message(connection,
                          "You don't own this planet!")
         else:
@@ -224,10 +235,11 @@ class Claims(StorageCommandPlugin):
              doc="Transfer ownership of the planet to another person.")
     def _change_owner(self, data, connection):
         alias = connection.player.alias
+        uuid = connection.player.uuid
         location = connection.player.location
         target = self.plugins.player_manager.get_player_by_alias(" ".join(data))
         if target is not None:
-            if not self.is_owner(alias, location):
+            if not self.is_owner(uuid, location):
                 send_message(connection, "You don't own this planet!")
             elif location.locationtype() is "ShipWorld":
                 send_message(connection, "Can't transfer ownership of your "
@@ -236,17 +248,17 @@ class Claims(StorageCommandPlugin):
                 send_message(connection, "Target is not high enough rank to "
                                          "own a planet!")
             else:
-                if target.alias not in self.storage["owners"]:
-                    self.storage["owners"][target.alias] = []
-                if len(self.storage["owners"][target.alias]) >= \
+                if target.uuid not in self.storage["owners"]:
+                    self.storage["owners"][target.uuid] = []
+                if len(self.storage["owners"][target.uuid]) >= \
                         self.max_claims:
                     send_message(connection, "The target player has reached "
                                              "the maximum number of claims!")
                     return
-                self.storage["owners"][target.alias].append(str(location))
-                self.storage["owners"][alias].remove(str(location))
-                if len(self.storage["owners"][alias]) == 0:
-                    self.storage["owners"].pop(alias)
+                self.storage["owners"][target.uuid].append(str(location))
+                self.storage["owners"][uuid].remove(str(location))
+                if len(self.storage["owners"][uuid]) == 0:
+                    self.storage["owners"].pop(uuid)
                 send_message(connection, "Transferred ownership of {} to {}."
                              .format(location, target.alias))
                 try:
@@ -266,7 +278,7 @@ class Claims(StorageCommandPlugin):
              role=Registered,
              doc="List all of the planets you've claimed.")
     def _list_claims(self, data, connection):
-        alias = connection.player.alias
+        uuid = connection.player.uuid
         send_message(connection, "You've claimed the following worlds:")
-        for location in self.storage["owners"][alias]:
+        for location in self.storage["owners"][uuid]:
             send_message(connection, self._pretty_world_name(location))

--- a/plugins/command_dispatcher.py
+++ b/plugins/command_dispatcher.py
@@ -12,9 +12,12 @@ Updated for release: kharidiron
 """
 
 import asyncio
+import packets
 
 from base_plugin import BasePlugin
 from utilities import extractor, get_syntax, send_message
+from data_parser import ChatSent
+from pparser import build_packet
 
 
 class CommandDispatcher(BasePlugin):
@@ -42,6 +45,16 @@ class CommandDispatcher(BasePlugin):
         """
         if data['parsed']['message'].startswith(
                 self.plugin_config.command_prefix):
+            if data['parsed']['message'].startswith("{}sb:".format(
+                    self.plugin_config.command_prefix)):
+                # Bypass StarryPy command processing and send to the
+                # starbound server
+                cmd = data['parsed']['message'].replace("sb:", "")
+                pkt = ChatSent.build({"message": cmd, "send_mode": data[
+                    'parsed']['send_mode']})
+                full = build_packet(packets.packets['chat_sent'], pkt)
+                yield from connection.client_raw_write(full)
+                return False
             to_parse = data['parsed']['message'][len(
                 self.plugin_config.command_prefix):].split()
 

--- a/plugins/discord_bot.py
+++ b/plugins/discord_bot.py
@@ -199,20 +199,23 @@ class DiscordPlugin(BasePlugin):
         :return: Null
         """
         nick = message.author.display_name
+        text = message.clean_content
+        server = message.server
         if message.author.id != cls.client_id:
             if message.content[0] == ".":
-                asyncio.ensure_future(cls.handle_command(message.content[
-                                                         1:]))
+                asyncio.ensure_future(cls.handle_command(message.content[1:]))
             else:
+                for emote in server.emojis:
+                    text = text.replace("<:{}:{}>".format(emote.name,emote.id),
+                                        ":{}:".format(emote.name))
                 yield from cls.factory.broadcast("<^orange;Discord^reset;> <{}> {}"
-                                                 "".format(nick, message.content),
+                                                 "".format(nick, text),
                                                  mode=ChatReceiveMode.BROADCAST)
                 if cls.config.get_plugin_config(cls.name)["log_discord"]:
-                    cls.logger.info("<{}> {}".format(nick, message.content))
+                    cls.logger.info("<{}> {}".format(nick, text))
                 if link_plugin_if_available(cls, "irc_bot"):
                     asyncio.ensure_future(cls.plugins['irc_bot'].bot_write(
-                                          "<DC><{}> {}".format(nick,
-                                                               message.content)))
+                                          "<DC><{}> {}".format(nick, text)))
 
     @asyncio.coroutine
     def make_announce(self, connection, circumstance):

--- a/plugins/discord_bot.py
+++ b/plugins/discord_bot.py
@@ -14,7 +14,7 @@ import discord
 
 from base_plugin import BasePlugin
 from plugins.player_manager import Owner, Guest
-from utilities import ChatSendMode, ChatReceiveMode
+from utilities import ChatSendMode, ChatReceiveMode, link_plugin_if_available
 
 bot = discord.Client()
 
@@ -62,6 +62,11 @@ class MockConnection:
         self.owner = owner
         self.player = MockPlayer()
 
+    @asyncio.coroutine
+    def send_message(self, *messages):
+        for message in messages:
+            yield from self.owner.bot_write(message)
+        return None
 
 # Discord listener
 
@@ -84,6 +89,8 @@ class DiscordPlugin(BasePlugin):
         "log_discord": False
     }
     client_id = None
+    connection = None
+    dispatcher = None
 
     def __init__(self):
         super().__init__()
@@ -93,14 +100,18 @@ class DiscordPlugin(BasePlugin):
         self.connection = None
         self.prefix = None
         self.dispatcher = None
-        self.bot = None
+        self.bot = bot
         self.color_strip = re.compile("\^(.*?);")
         self.sc = None
+        self.irc_bot_exists = False
+        self.irc_bot = None
 
     def activate(self):
         super().activate()
         self.connection = MockConnection(self)
+        DiscordPlugin.connection = self.connection
         self.dispatcher = self.plugins.command_dispatcher
+        DiscordPlugin.dispatcher = self.dispatcher
         self.prefix = self.config.get_plugin_config("command_dispatcher")[
             "command_prefix"]
         self.token = self.config.get_plugin_config(self.name)["token"]
@@ -153,9 +164,8 @@ class DiscordPlugin(BasePlugin):
 
             if data["parsed"]["send_mode"] == ChatSendMode.UNIVERSE:
                 asyncio.ensure_future(
-                    bot.send_message(bot.get_channel(self.channel),
-                                     "<{}> {}".format(connection.player.alias,
-                                                      msg)))
+                    self.bot_write("**<{}>** {}".format(connection.player.alias,
+                                                        msg)))
         return True
 
     # Helper functions - Used by commands
@@ -190,11 +200,19 @@ class DiscordPlugin(BasePlugin):
         """
         nick = message.author.display_name
         if message.author.id != cls.client_id:
-            yield from cls.factory.broadcast("<^orange;Discord^reset;> <{}> {}"
-                                             "".format(nick, message.content),
-                                             mode=ChatReceiveMode.BROADCAST)
-            if cls.config.get_plugin_config(cls.name)["log_discord"]:
-                cls.logger.info("<{}> {}".format(nick, message.content))
+            if message.content[0] == ".":
+                asyncio.ensure_future(cls.handle_command(message.content[
+                                                         1:]))
+            else:
+                yield from cls.factory.broadcast("<^orange;Discord^reset;> <{}> {}"
+                                                 "".format(nick, message.content),
+                                                 mode=ChatReceiveMode.BROADCAST)
+                if cls.config.get_plugin_config(cls.name)["log_discord"]:
+                    cls.logger.info("<{}> {}".format(nick, message.content))
+                if link_plugin_if_available(cls, "irc_bot"):
+                    asyncio.ensure_future(cls.plugins['irc_bot'].bot_write(
+                                          "<DC><{}> {}".format(nick,
+                                                               message.content)))
 
     @asyncio.coroutine
     def make_announce(self, connection, circumstance):
@@ -206,7 +224,26 @@ class DiscordPlugin(BasePlugin):
         :return: Null.
         """
         yield from asyncio.sleep(1)
-        yield from bot.send_message(
-            bot.get_channel(self.channel),
-            "{} has {} the server.".format(connection.player.alias,
-                                           circumstance))
+        yield from self.bot_write("{} has {} the server.".format(
+            connection.player.alias, circumstance))
+
+    @asyncio.coroutine
+    def handle_command(data):
+        split = data.split()
+        command = split[0]
+        to_parse = split[1:]
+        DiscordPlugin.connection.player.roles = DiscordPlugin.connection.player.guest
+        if command in DiscordPlugin.dispatcher.commands:
+            # Only handle commands that work from Discord
+            if command in ('who', 'help'):
+                yield from DiscordPlugin.dispatcher.run_command(command,
+                                                       DiscordPlugin.connection,
+                                                       to_parse)
+        else:
+            yield from self.bot_write("Command not found.")
+
+    @asyncio.coroutine
+    def bot_write(self, msg, target=None):
+        if target is None:
+            target = bot.get_channel(self.channel)
+        asyncio.ensure_future(bot.send_message(target, msg))

--- a/plugins/discord_bot.py
+++ b/plugins/discord_bot.py
@@ -147,7 +147,7 @@ class DiscordPlugin(BasePlugin):
 
     def on_chat_sent(self, data, connection):
         """
-        Hook on message being broadcast on server. Display it in IRC.
+        Hook on message being broadcast on server. Display it in Discord.
 
         If 'sc' is True, colors are stripped from game text. e.g. -
 

--- a/plugins/general_commands.py
+++ b/plugins/general_commands.py
@@ -73,7 +73,7 @@ class GeneralCommands(SimpleCommandPlugin):
                 "UUID: ^yellow;{}^green;\n"
                 "IP address: ^cyan;{}^green;\n"
                 "Team ID: ^cyan;{}^green;\n"
-                "Current location: ^yellow;{}^green;"
+                "Current location: ^yellow;{}^green;\n"
                 "Last seen: ^yellow;{}^green;".format(
                     target.alias, l,
                     target.name,

--- a/plugins/general_commands.py
+++ b/plugins/general_commands.py
@@ -214,7 +214,14 @@ class GeneralCommands(SimpleCommandPlugin):
         :param connection: The connection from which the packet came.
         :return: Null.
         """
-        alias = " ".join(data)
+        if len(data) > 1 and connection.player.check_role(Admin):
+            target = self.plugins.player_manager.find_player(data[0])
+            alias = " ".join(data[1:])
+        else:
+            alias = " ".join(data)
+            target = connection.player
+        if len(data) == 0:
+            alias = connection.player.name
         if self.plugins.player_manager.get_player_by_alias(alias):
             raise ValueError("There's already a user by that name.")
         else:
@@ -223,8 +230,8 @@ class GeneralCommands(SimpleCommandPlugin):
                 send_message(connection,
                              "Nickname contains no valid characters.")
                 return
-            old_alias = connection.player.alias
-            connection.player.alias = clean_alias
+            old_alias = target.alias
+            target.alias = clean_alias
             broadcast(connection, "{}'s name has been changed to {}".format(
                 old_alias, clean_alias))
 

--- a/plugins/general_commands.py
+++ b/plugins/general_commands.py
@@ -10,6 +10,8 @@ import asyncio
 
 import sys
 
+import datetime
+
 import packets
 import pparser
 import data_parser
@@ -55,6 +57,7 @@ class GeneralCommands(SimpleCommandPlugin):
         self.maintenance = False
         self.rejection_message = self.config.get_plugin_config(self.name)[
             "maintenance_message"]
+        self.start_time = datetime.datetime.now()
 
     def generate_whois(self, target):
         """
@@ -275,6 +278,19 @@ class GeneralCommands(SimpleCommandPlugin):
         send_message(connection,
                      "{} players on planet:\n{}".format(len(ret_list),
                                                         ", ".join(ret_list)))
+
+    @Command("uptime",
+             role=Whoami,
+             doc="Displays the time since the server started.")
+    def _uptime(self, data, connection):
+        """
+        Displays the time since the server started.
+        :param data: The packet containing the command.
+        :param connection: The connection from which the packet came.
+        :return: Null.
+        """
+        current_time = datetime.datetime.now() - self.start_time
+        yield from send_message(connection, "Uptime: {}".format(current_time))
 
     @Command("shutdown",
              role=Shutdown,

--- a/plugins/general_commands.py
+++ b/plugins/general_commands.py
@@ -224,9 +224,8 @@ class GeneralCommands(SimpleCommandPlugin):
                 return
             old_alias = connection.player.alias
             connection.player.alias = clean_alias
-            broadcast(self.factory,
-                      "{}'s name has been changed to {}".format(old_alias,
-                                                                clean_alias))
+            broadcast(connection, "{}'s name has been changed to {}".format(
+                old_alias, clean_alias))
 
     @Command("whoami",
              role=Whoami,

--- a/plugins/general_commands.py
+++ b/plugins/general_commands.py
@@ -138,7 +138,7 @@ class GeneralCommands(SimpleCommandPlugin):
         if len(data) == 0:
             raise SyntaxWarning("No target provided.")
         name = " ".join(data)
-        info = self.plugins['player_manager'].get_player_by_alias(name)
+        info = self.plugins['player_manager'].find_player(name)
         if info is not None:
             send_message(connection, self.generate_whois(info))
         else:
@@ -161,7 +161,7 @@ class GeneralCommands(SimpleCommandPlugin):
                 cannot be resolved.
         """
         arg_count = len(data)
-        target = self.plugins.player_manager.get_player_by_alias(data[0])
+        target = self.plugins.player_manager.find_player(data[0])
         if arg_count == 1:
             target = connection.player
             item = data[0]

--- a/plugins/general_commands.py
+++ b/plugins/general_commands.py
@@ -64,9 +64,11 @@ class GeneralCommands(SimpleCommandPlugin):
         :param target: Player object to be looked up.
         :return: String: The data about the player.
         """
-        l = ""
+        logged_in = "(^green;Online^reset;)"
+        last_seen = "Now"
         if not target.logged_in:
-            l = "(^red;Offline^reset;)"
+            logged_in = "(^red;Offline^reset;)"
+            last_seen = target.last_seen
         return ("Name: {} {}\n"
                 "Raw Name: {}\n"
                 "Roles: ^yellow;{}^green;\n"
@@ -75,14 +77,14 @@ class GeneralCommands(SimpleCommandPlugin):
                 "Team ID: ^cyan;{}^green;\n"
                 "Current location: ^yellow;{}^green;\n"
                 "Last seen: ^yellow;{}^green;".format(
-                    target.alias, l,
+                    target.alias, logged_in,
                     target.name,
                     ", ".join(target.roles),
                     target.uuid,
                     target.ip,
                     target.team_id,
                     target.location,
-                    target.last_seen))
+                    last_seen))
 
     def on_connect_success(self, data, connection):
         if self.maintenance and "SuperAdmin" not in connection.player.roles:

--- a/plugins/general_commands.py
+++ b/plugins/general_commands.py
@@ -91,7 +91,6 @@ class GeneralCommands(SimpleCommandPlugin):
             pkt = pparser.build_packet(packets.packets['connect_failure'],
                                        fail)
             yield from connection.raw_write(pkt)
-            print("Rejection message sent. Pkt: {}".format(fail))
             return False
         else:
             return True

--- a/plugins/irc_bot.py
+++ b/plugins/irc_bot.py
@@ -229,7 +229,7 @@ class IRCPlugin(BasePlugin):
         """
         if data[0] == ".":
             asyncio.ensure_future(self.handle_command(target, data[1:], mask))
-        elif target == self.channel:
+        elif target.lower() == self.channel.lower():
             nick = mask.split("!")[0]
             asyncio.ensure_future(self.send_message(data, nick))
         return None

--- a/plugins/irc_bot.py
+++ b/plugins/irc_bot.py
@@ -130,6 +130,7 @@ class IRCPlugin(BasePlugin):
         self.ops = None
         self.color_strip = re.compile("\^(.*?);")
         self.sc = None
+        self.discord_active = False
 
     def activate(self):
         super().activate()
@@ -161,6 +162,8 @@ class IRCPlugin(BasePlugin):
         self.bot.attach_events(y)
         self.bot.attach_events(z)
         self.bot.create_connection()
+
+        self.discord_active = link_plugin_if_available(self, 'discord_bot')
 
         self.ops = set()
         asyncio.ensure_future(self.update_ops())
@@ -244,7 +247,7 @@ class IRCPlugin(BasePlugin):
                 move = "left"
             if self.config.get_plugin_config(self.name)["log_irc"]:
                 self.logger.info("{} has {} the channel.".format(nick, move))
-            if link_plugin_if_available(self, "discord_bot"):
+            if self.discord_active:
                 discord = self.plugins['discord_bot']
                 asyncio.ensure_future(discord.bot.send_message(
                     discord.bot.get_channel(discord.channel), "<IRC> **{}** "
@@ -288,7 +291,7 @@ class IRCPlugin(BasePlugin):
 
                 if self.config.get_plugin_config(self.name)["log_irc"]:
                     self.logger.info(" -*- " + nick + " " + message)
-                if link_plugin_if_available(self, "discord_bot"):
+                if self.discord_active:
                     discord = self.plugins['discord_bot']
                     asyncio.ensure_future(discord.bot.send_message(discord.bot.get_channel(
                         discord.channel), "-*- {} {}".format(nick, message)))
@@ -299,7 +302,7 @@ class IRCPlugin(BasePlugin):
         else:
             if self.config.get_plugin_config(self.name)["log_irc"]:
                 self.logger.info("<" + nick + "> " + message)
-            if link_plugin_if_available(self, "discord_bot"):
+            if self.discord_active:
                 discord = self.plugins['discord_bot']
                 asyncio.ensure_future(discord.bot_write("<IRC> **<{}>** {}"
                                                         .format(nick, message)))

--- a/plugins/irc_bot.py
+++ b/plugins/irc_bot.py
@@ -332,7 +332,8 @@ class IRCPlugin(BasePlugin):
                                                        self.connection,
                                                        to_parse)
         else:
-            yield from self.bot_write(target, "Command not found.")
+            yield from self.bot_write("Command \"{}\" not found.".format(
+                                      command), target)
 
     @asyncio.coroutine
     def update_ops(self):

--- a/plugins/irc_bot.py
+++ b/plugins/irc_bot.py
@@ -335,6 +335,9 @@ class IRCPlugin(BasePlugin):
                 yield from self.dispatcher.run_command(command,
                                                        self.connection,
                                                        to_parse)
+            else:
+                yield from self.bot_write("Command \"{}\" is not usable from "
+                                          "IRC.".format(command))
         else:
             yield from self.bot_write("Command \"{}\" not found.".format(
                                       command), target)

--- a/plugins/irc_bot.py
+++ b/plugins/irc_bot.py
@@ -325,7 +325,11 @@ class IRCPlugin(BasePlugin):
         self.connection.player.roles = self.connection.player.guest
         if mask.split("!")[0] in self.ops:
             self.connection.player.roles = self.connection.player.owner
-        if command in self.dispatcher.commands:
+        if command.startswith(".") or command.startswith(self.prefix):
+            # It's probably not meant to be a command
+            nick = mask.split("!")[0]
+            yield from self.send_message("." + data, nick)
+        elif command in self.dispatcher.commands:
             # Only handle commands that work from IRC
             if command in ('who', 'help'):
                 yield from self.dispatcher.run_command(command,

--- a/plugins/planet_protect.py
+++ b/plugins/planet_protect.py
@@ -304,7 +304,7 @@ class PlanetProtect(StorageCommandPlugin):
         :return: Null.
         """
         location = connection.player.location
-        p = self.plugins.player_manager.get_player_by_alias(" ".join(data))
+        p = self.plugins.player_manager.find_player(" ".join(data))
         if p is not None:
             protection = self.get_protection(location)
             protection.add_builder(p)
@@ -336,7 +336,7 @@ class PlanetProtect(StorageCommandPlugin):
         :param connection: The connection from which the packet came.
         :return: Null.
         """
-        p = self.plugins.player_manager.get_player_by_alias(" ".join(data))
+        p = self.plugins.player_manager.find_player(" ".join(data))
         if p is not None:
             protection = self.get_protection(connection.player.location)
             protection.del_builder(p)

--- a/plugins/player_manager.py
+++ b/plugins/player_manager.py
@@ -449,7 +449,7 @@ class PlayerManager(SimpleCommandPlugin):
 
     def _set_offline(self, connection):
         """
-        Convenince function to set all the players variables to off.
+        Convenience function to set all the players variables to off.
 
         :param connection: The connection to turn off.
         :return: Boolean, True. Always True, since called from the on_ packets.

--- a/plugins/player_manager.py
+++ b/plugins/player_manager.py
@@ -765,6 +765,9 @@ class PlayerManager(SimpleCommandPlugin):
                 p.species = species
             if p.name != name:
                 p.name = name
+                p.alias = self.clean_name(name)
+                if p.alias is None:
+                    p.alias = uuid[0:4]
             return p
         else:
             if self.get_player_by_name(alias) is not None:

--- a/plugins/player_manager.py
+++ b/plugins/player_manager.py
@@ -572,16 +572,6 @@ class PlayerManager(SimpleCommandPlugin):
         else:
             return 0
 
-    def get_player_by_uuid(self, uuid):
-        """
-        Grab a hook to a player by their uuid. Returns player object.
-
-        :param uuid: String: UUID of player to check.
-        :return: Mixed: Player object.
-        """
-        if uuid in self.shelf["players"]:
-            return self.shelf["players"][uuid]
-
     def ban_by_ip(self, ip, reason, connection):
         """
         Ban a player based on their IP address. Should be compatible with both
@@ -622,7 +612,7 @@ class PlayerManager(SimpleCommandPlugin):
         :param connection: Connection of target player to be banned.
         :return: Null
         """
-        p = self.get_player_by_alias(name)
+        p = self.find_player(name)
         if p is not None:
             self.ban_by_ip(p.ip, reason, connection)
         else:
@@ -639,7 +629,7 @@ class PlayerManager(SimpleCommandPlugin):
         :param connection: Connection of target player to be banned.
         :return: Null
         """
-        p = self.get_player_by_alias(name)
+        p = self.find_player(name)
         if p is not None:
             self.unban_by_ip(p.ip, connection)
         else:
@@ -689,6 +679,16 @@ class PlayerManager(SimpleCommandPlugin):
             self.plugin_shelf[name] = DotDict({})
         return self.plugin_shelf[name]
 
+    def get_player_by_uuid(self, uuid):
+        """
+        Grab a hook to a player by their uuid. Returns player object.
+
+        :param uuid: String: UUID of player to check.
+        :return: Mixed: Player object.
+        """
+        if uuid in self.shelf["players"]:
+            return self.shelf["players"][uuid]
+
     def get_player_by_name(self, name, check_logged_in=False) -> Player:
         """
         Grab a hook to a player by their name. Return Boolean value if only
@@ -720,6 +720,41 @@ class PlayerManager(SimpleCommandPlugin):
             if player.alias.lower() == lname:
                 if not check_logged_in or player.logged_in:
                     return player
+
+    def get_player_by_client_id(self, id, check_logged_in=False) -> Player:
+        """
+        Grab a hook to a player by their client id. Return Boolean value if
+        only checking login status. Returns player object otherwise.
+
+        :param id: Integer: Client Id of the player to check.
+        :param check_logged_in: Boolean: Whether we just want login status
+                                (true), or the player's server object (false).
+        :return: Mixed: Boolean on logged_in check, player object otherwise.
+        """
+        iid = int(id)
+        for player in self.shelf["players"].values():
+            if player.client_id == iid:
+                if not check_logged_in or player.logged_in:
+                    return player
+
+    def find_player(self, search, check_logged_in=False):
+        """
+        Convenience method to try and find a player by a variety of methods.
+        Checks for alias, then raw name, then client id.
+
+        :param search: The alias, raw name, or id of the player to check.
+        :param check_logged_in: Boolean: Return the login status only if true.
+        :return: Mixed: Boolean on logged_in check, player object otherwise.
+        """
+        player = self.get_player_by_alias(search, check_logged_in)
+        if player is not None:
+            return player
+        player = self.get_player_by_name(search, check_logged_in)
+        if player is not None:
+            return player
+        player = self.get_player_by_client_id(search, check_logged_in)
+        if player is not None:
+            return player
 
     @asyncio.coroutine
     def _add_or_get_player(self, uuid, species, name="", last_seen=None, roles=None,
@@ -883,7 +918,7 @@ class PlayerManager(SimpleCommandPlugin):
         except IndexError:
             reason = "No reason given."
 
-        p = self.get_player_by_alias(alias)
+        p = self.find_player(alias)
         if p is None:
             send_message(connection,
                          "Couldn't find a player with name {}".format(alias))
@@ -999,7 +1034,7 @@ class PlayerManager(SimpleCommandPlugin):
         if not data[1:]:
             raise SyntaxWarning("Please provide a target player.")
         alias = " ".join(data[1:])
-        p = self.get_player_by_alias(alias)
+        p = self.find_player(alias)
         try:
             if role.lower() not in (x.__name__.lower() for x in Owner.roles):
                 raise LookupError("Unknown role {}".format(role))
@@ -1079,7 +1114,7 @@ class PlayerManager(SimpleCommandPlugin):
         else:
             force = False
         alias = " ".join(data)
-        player = self.get_player_by_alias(alias)
+        player = self.find_player(alias)
         if player is None:
             raise NameError
         if (not force) and player.logged_in:

--- a/plugins/player_manager.py
+++ b/plugins/player_manager.py
@@ -291,6 +291,7 @@ class PlayerManager(SimpleCommandPlugin):
         connection.player.client_id = response["client_id"]
         connection.state = State.CONNECTED
         connection.player.logged_in = True
+        connection.player.last_seen = datetime.datetime.now()
         self.players_online.append(connection.player.uuid)
         return True
 
@@ -456,6 +457,7 @@ class PlayerManager(SimpleCommandPlugin):
         connection.player.connection = None
         connection.player.logged_in = False
         connection.player.location = None
+        connection.player.last_seen = datetime.datetime.now()
         self.players_online.remove(connection.player.uuid)
         return True
 

--- a/plugins/player_manager.py
+++ b/plugins/player_manager.py
@@ -466,6 +466,8 @@ class PlayerManager(SimpleCommandPlugin):
         alias = non_ascii_strip.sub("", alias)
         multi_whitespace_strip = re.compile("[\s]{2,}")
         alias = multi_whitespace_strip.sub(" ", alias)
+        trailing_leading_whitespace_strip = re.compile("^[ \s]+|[ \s]+$")
+        alias = trailing_leading_whitespace_strip.sub("", alias)
         match_non_whitespace = re.compile("[\S]")
         if match_non_whitespace.search(alias) is None:
             return None

--- a/plugins/poi.py
+++ b/plugins/poi.py
@@ -90,7 +90,8 @@ class POI(StorageCommandPlugin):
             return
         planet = connection.player.location
         poi = " ".join(data).lower()
-        if str(planet) != "{}'s ship".format(connection.player.alias):
+        if planet.locationtype() != "ShipWorld" or planet.uuid.decode("utf-8")\
+                != connection.player.uuid:
             send_message(connection,
                          "You must be on your ship for this to work.")
             return

--- a/plugins/spawn.py
+++ b/plugins/spawn.py
@@ -105,6 +105,7 @@ class Spawn(StorageCommandPlugin):
                          "You must be standing on a planet for this to work.")
             return
         self.storage["spawn"]["spawn_location"] = planet
+        send_message(connection, "Spawn planet set to {}.".format(str(planet)))
 
     @Command("show_spawn",
              role=Moderator,

--- a/plugins/spawn.py
+++ b/plugins/spawn.py
@@ -75,9 +75,11 @@ class Spawn(StorageCommandPlugin):
         # TODO - Or maybe not - when player already above spawn planet,
         # nothing happens. It would be nice to generate an alert on this case.
         planet = connection.player.location
-        if str(planet) != "{}'s ship".format(connection.player.alias):
+        if planet.locationtype() != "ShipWorld" or planet.uuid.decode("utf-8")\
+                != connection.player.uuid:
             send_message(connection,
                          "You must be on your ship for this to work.")
+            return
         try:
             yield from self._move_ship(connection)
             send_message(connection,

--- a/plugins/warp_plugin.py
+++ b/plugins/warp_plugin.py
@@ -63,7 +63,7 @@ class WarpPlugin(SimpleCommandPlugin):
         full = build_packet(packets.packets['player_warp'], wp)
         yield from from_player.connection.client_raw_write(full)
 
-    @Command("warp", "tp",
+    @Command("tp",
              role=Warp,
              doc="Warps a player to another player.",
              syntax=("[from player=self]", "(to player)"))

--- a/plugins/warp_plugin.py
+++ b/plugins/warp_plugin.py
@@ -35,7 +35,7 @@ class WarpPlugin(SimpleCommandPlugin):
 
     def activate(self):
         super().activate()
-        self.get_by_alias = self.plugins.player_manager.get_player_by_alias
+        self.find_player = self.plugins.player_manager.find_player
 
     @asyncio.coroutine
     def warp_player_to_player(self, from_player, to_player):
@@ -70,10 +70,10 @@ class WarpPlugin(SimpleCommandPlugin):
     def warp(self, data, connection):
         if len(data) == 1:
             from_player = connection.player
-            to_player = self.get_by_alias(data[0], check_logged_in=True)
+            to_player = self.find_player(data[0], check_logged_in=True)
         elif len(data) == 2:
-            from_player = self.get_by_alias(data[0], check_logged_in=True)
-            to_player = self.get_by_alias(data[1], check_logged_in=True)
+            from_player = self.find_player(data[0], check_logged_in=True)
+            to_player = self.find_player(data[1], check_logged_in=True)
         else:
             raise SyntaxWarning
         if from_player is None or to_player is None:
@@ -96,10 +96,10 @@ class WarpPlugin(SimpleCommandPlugin):
     def ship_warp(self, data, connection):
         if len(data) == 1:
             from_player = connection.player
-            to_player = self.get_by_alias(data[0], check_logged_in=True)
+            to_player = self.find_player(data[0], check_logged_in=True)
         elif len(data) == 2:
-            from_player = self.get_by_alias(data[0], check_logged_in=True)
-            to_player = self.get_by_alias(data[1], check_logged_in=True)
+            from_player = self.find_player(data[0], check_logged_in=True)
+            to_player = self.find_player(data[1], check_logged_in=True)
         else:
             raise SyntaxWarning
         if from_player is None or to_player is None:

--- a/utilities.py
+++ b/utilities.py
@@ -331,6 +331,9 @@ def link_plugin_if_available(self, plugin):
         self.logger.debug("{} available.".format(plugin))
         self.plugins[plugin] = \
             self.factory.plugin_manager.list_plugins()[plugin]
+        return True
+    else:
+        return False
 
 
 class Command:


### PR DESCRIPTION
- Rename `/warp` to `/tp` to allow use of in-built warp command
- Add missing line break to `/whois`
- Strip trailing and leading whitespace from aliases
- Rebuild alias of player who changes their character name
- Return on `link_plugin_if_available` whether the plugin was linked or not
- Use UUIDs instead of aliases in Claims storage
- Add user to build list when they are transferred ownership of a claim
- Add feedback messages for unprotected planet on `/add_helper`, `/rm_helper`, `/change_owner`, `/helper_list`
- Add message if no worlds are claimed on `/list_claims`
- Use UUIDs to check ship owner on `/spawn`, `/poi`, and the ship auto-claim function
- Fix broadcast message when `/nick` is used to change alias
- Add message when `/set_spawn` is used
- Add `sb:` bypass for commands
- Allow targeted commands to get by alias, raw name, or client id
- Allow Admins to `/nick` other players
- `/nick` without arguments resets the player's name
- Add `/uptime` command to see the time since the server was started
- IRC Bot: Send "Command not found" message correctly
- IRC Bot: Don't process messages with multiple `.`s or `./` as commands
- IRC Bot: Optionally announce channel join/leaves
- IRC Bot: Don't use case sensitivity when checking the channel to send messages to
- Discord/IRC integration
- Discord Bot: Support limited commands
- Discord Bot: Format mentions and server emoji nicely