### PR TITLE
Add 'whereami' command

### DIFF
--- a/config/config.json.default
+++ b/config/config.json.default
@@ -27,9 +27,9 @@
         "discord_bot": {
             "channel": "-- channel id --",
             "client_id": "-- client_id --",
-            "log_discord": false
+            "log_discord": false,
             "strip_colors": true,
-            "token": "-- token --",
+            "token": "-- token --"
         },
         "general_commands": {
             "maintenance_message": "This server is currently in maintenance mode and is not accepting new connections."

--- a/plugins/general_commands.py
+++ b/plugins/general_commands.py
@@ -125,6 +125,29 @@ class GeneralCommands(SimpleCommandPlugin):
                      "{} players online:\n{}".format(len(ret_list),
                                                      ", ".join(ret_list)))
 
+    @Command("whereami",
+             doc="Displays your current location.")
+    def _whereami(self, data, connection):
+        """
+        Displays the user's current location.
+        This mainly exists to prevent Starbound's default "whereami" command
+        from leaking sensitive UUIDs when in a player's ship or instance world.
+
+        :param data: The packet containing the command.
+        :param connection: The connection from which the packet came.
+        :return: Null.
+        """
+        location = connection.player.location
+        if connection.player.check_role(Moderator):
+            send_message(connection,
+                "Current location: {}".format(location))
+        elif hasattr(location, "locationtype") and (location.locationtype() == "CelestialWorld"):
+            send_message(connection,
+                "Current location: {}".format(location))
+        else:
+            send_message(connection,
+                "Current location: a ship or instance world.")
+
     @Command("whois",
              role=Whois,
              doc="Returns client data about the specified user.",


### PR DESCRIPTION
Starbound's built-in "whereami" command leaks player UUIDs when run on another player's ship or instance world. Once this UUID is obtained, it can be used to easily and effectively impersonate the other player.

Since this has rather severe implications, including impersonation of owners and staff members, I have added a replacement "whereami" command.