### PR TITLE
Implement a more robust authentication mechanism for privileged players.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,56 @@ for the lines below, and change them to specify port 21024:
   "queryServerPort" : 21025,
 ```
 
+While editing your `starbound_server.config`, you should also add some accounts
+for your server's staff, if you have not done so already. StarryPy3k's
+authentication plugin uses Starbound's account system to authenticate privileged
+users (moderator and up), so you will need at least one account before your
+staff can join the server. Look for the lines below:
+
+```
+  "serverUsers" : {
+  },
+```
+
+And add some accounts (preferrably one per staff member) using the format below.
+Note: you do **not** need to set "admin" to "false" - set it to "true" if you
+would like this account to have administrator privileges on the underlying
+Starbound dedicated server.
+
+```
+  "serverUsers" : {
+    "repalceWithAccountName" : {
+      "admin" : false,
+      "password" : "replaceWithAccountPassword"
+    },
+    "repalceWithAnotherAccountName" : {
+      "admin" : false,
+      "password" : "replaceWithAnotherAccountPassword"
+    }
+  },
+```
+
 ### StarryPy Proxy Configuration
 An example configuration file, `config.json.default`, is provided in the
 `config` directory.  Copy that file to a new one named `config.json` in the
 same location.  Open it in your text editor of choice.  The following are the
 most likely changes you will have to make:
+
+```
+        "basic_auth": {
+            "owner_sb_account": "-- REPLACE WITH OWNER ACCOUNT --",
+            "staff_sb_accounts": [
+                "-- REPLACE WITH STARBOUND ACCOUNT NAME --",
+                "-- REPLACE WITH ANOTHER --",
+                "-- SO ON AND SO FORTH --"
+            ]
+        },
+```
+
+The section above is used by StarryPy3k's authentication plugin to define
+Statbound accounts that staff members can use to authenticate. Edit the example
+above to use **only** the account **names** (no passwords) that you just set up
+in your `starbound_server.config` file.
 
 ```
         "irc_bot": {

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ for the lines below, and change them to specify port 21024:
 
 While editing your `starbound_server.config`, you should also add some accounts
 for your server's staff, if you have not done so already. StarryPy3k's
-authentication plugin uses Starbound's account system to authenticate privileged
+basic_auth plugin uses Starbound's account system to authenticate privileged
 users (moderator and up), so you will need at least one account before your
 staff can join the server. Look for the lines below:
 
@@ -51,7 +51,7 @@ staff can join the server. Look for the lines below:
 ```
 
 And add some accounts (preferrably one per staff member) using the format below.
-Note: you do **not** need to set "admin" to "false" - set it to "true" if you
+Note: you do **not** need to set "admin" to "false". Set it to "true" if you
 would like this account to have administrator privileges on the underlying
 Starbound dedicated server.
 
@@ -76,6 +76,7 @@ most likely changes you will have to make:
 
 ```
         "basic_auth": {
+            "enabled": true,
             "owner_sb_account": "-- REPLACE WITH OWNER ACCOUNT --",
             "staff_sb_accounts": [
                 "-- REPLACE WITH STARBOUND ACCOUNT NAME --",
@@ -85,8 +86,8 @@ most likely changes you will have to make:
         },
 ```
 
-The section above is used by StarryPy3k's authentication plugin to define
-Statbound accounts that staff members can use to authenticate. Edit the example
+The section above is used by StarryPy3k's basic_auth plugin to define
+Starbound accounts that staff members can use to authenticate. Edit the example
 above to use **only** the account **names** (no passwords) that you just set up
 in your `starbound_server.config` file.
 

--- a/config/config.json.default
+++ b/config/config.json.default
@@ -5,6 +5,7 @@
     "plugin_path": "./plugins",
     "plugins": {
         "basic_auth": {
+            "enabled": true,
             "owner_sb_account": "-- REPLACE WITH OWNER ACCOUNT --",
             "staff_sb_accounts": [
                 "-- REPLACE WITH STARBOUND ACCOUNT NAME --",

--- a/config/config.json.default
+++ b/config/config.json.default
@@ -4,6 +4,14 @@
     "packet_reap_time": 600,
     "plugin_path": "./plugins",
     "plugins": {
+        "basic_auth": {
+            "owner_sb_account": "-- REPLACE WITH OWNER ACCOUNT --",
+            "staff_sb_accounts": [
+                "-- REPLACE WITH STARBOUND ACCOUNT NAME --",
+                "-- REPLACE WITH ANOTHER --",
+                "-- SO ON AND SO FORTH --"
+            ]
+        },
         "chat_enhancements": {
             "chat_timestamps": true,
             "colors": {

--- a/data_parser.py
+++ b/data_parser.py
@@ -671,7 +671,7 @@ class ClientConnect(Struct):
     max_fuel = UBInt32
     crew_size = UBInt32
     # Junk means, I don't know what this value represents... <_<
-    junk2 = BFloat32
+    junk2 = UBInt32
     ship_upgrades = StringSet
     # account really does appear to be a StringSet despite always being a single string.
     account = StringSet

--- a/data_parser.py
+++ b/data_parser.py
@@ -669,11 +669,12 @@ class ClientConnect(Struct):
     shipdata = WorldChunks
     ship_level = UBInt32
     max_fuel = UBInt32
+    crew_size = UBInt32
     # Junk means, I don't know what this value represents... <_<
-    junk2 = UBInt32
+    junk2 = BFloat32
     ship_upgrades = StringSet
-    intro_complete = Byte
-    account = StarString
+    # account really does appear to be a StringSet despite always being a single string.
+    account = StringSet
 
 
 class ClientDisconnectRequest(Struct):

--- a/plugins/basic_auth.py
+++ b/plugins/basic_auth.py
@@ -24,11 +24,25 @@ from packets import packets
 class BasicAuth(SimpleCommandPlugin):
     name = "basic_auth"
     depends = ["player_manager"]
-    default_config = {"staff_sb_accounts": [
+    default_config = {"enabled" : False,
+                      "staff_sb_accounts": [
                          "-- REPLACE WITH STARBOUND ACCOUNT NAME --",
                          "-- REPLACE WITH ANOTHER --",
                          "-- SO ON AND SO FORTH ---"],
                       "owner_sb_account" : "-- REPLACE WITH OWNER ACCOUNT --"}
+
+    def activate(self):
+        super().activate()
+        if self.config.get_plugin_config(self.name)["enabled"]:
+            self.logger.debug("Enabled.")
+            self.enabled = True
+        else:
+            self.enabled = False
+            self.logger.warning("+---------------< WARNING >---------------+")
+            self.logger.warning("| basic_auth plugin is disabled! You are  |")
+            self.logger.warning("| vulnerable to UUID spoofing attacks!    |")
+            self.logger.warning("| Consult README for enablement info.     |")
+            self.logger.warning("+-----------------------------------------+")
 
     def on_client_connect(self, data, connection):
         """
@@ -41,6 +55,8 @@ class BasicAuth(SimpleCommandPlugin):
                  failed connection.
         """
 
+        if not self.enabled:
+            return True
         uuid = data["parsed"]["uuid"].decode("ascii")
         account = data["parsed"]["account"][0]
         # Why [0]? Because 'account' is a StringSet.

--- a/plugins/basic_auth.py
+++ b/plugins/basic_auth.py
@@ -1,0 +1,98 @@
+"""
+StarryPy Basic Authentication Plugin
+
+Blocks UUID spoofing of staff members by forcing players with Moderator roles
+to log in with a whitelisted Starbound account.
+Permitted accounts are defined in StarryPy3k's configuration file.
+
+Original Authors: GermaniumSystem
+"""
+
+import asyncio
+
+import packets
+import utilities
+from plugins.player_manager import Owner, Moderator, Player
+from base_plugin import SimpleCommandPlugin
+from data_parser import ConnectFailure, ServerDisconnect
+from pparser import build_packet
+from utilities import State
+from packets import packets
+
+
+
+class BasicAuth(SimpleCommandPlugin):
+    name = "basic_auth"
+    depends = ["player_manager"]
+    default_config = {"staff_sb_accounts": [
+                         "-- REPLACE WITH STARBOUND ACCOUNT NAME --",
+                         "-- REPLACE WITH ANOTHER --",
+                         "-- SO ON AND SO FORTH ---"],
+                      "owner_sb_account" : "-- REPLACE WITH OWNER ACCOUNT --"}
+
+    def on_client_connect(self, data, connection):
+        """
+        Catch when a the client updates the server with its connection
+        details.
+
+        :param data:
+        :param connection:
+        :return: Boolean: True on successful connection, False on a
+                 failed connection.
+        """
+
+        uuid = data["parsed"]["uuid"].decode("ascii")
+        account = data["parsed"]["account"][0]
+        # Why [0]? Because 'account' is a StringSet.
+        # ...but it never contains more than one string.
+        player = self.plugins["player_manager"].get_player_by_uuid(uuid)
+        # We're only interested in players who already exist.
+        if player:
+            # The Owner account is quite dangerous, so it has a separate
+            # password to prevent a malicious staff member from taking over.
+            # Moderator thru SuperAdmin can still execute spoofing attacks on
+            # eachother, but this is being allowed for the sake of usability.
+            if (
+                   (
+                        player.check_role(Owner)
+                        and account == self.plugin_config.owner_sb_account
+                   ) or (
+                        not player.check_role(Owner)
+                        and player.check_role(Moderator)
+                        and account in self.plugin_config.staff_sb_accounts
+                   )
+            ):
+                # Everything checks out.
+                self.logger.info("Player with privileged UUID '{}' "
+                                 "successfully authenticated as "
+                                 "'{}'".format(uuid, account))
+                # We don't need to worry about anything after this.
+                # Starbound will take care of an incorrect password.
+            elif player.check_role(Owner) or player.check_role(Moderator):
+                # They're privileged but failed to authenticate. Kill it.
+                yield from connection.raw_write(
+                    self.build_rejection("^red;UNAUTHORIZED^reset;\n"
+                                         "Privileged players must log in with "
+                                         "an account defined in StarryPy3k's "
+                                         "config."))
+                connection.die()
+                self.logger.warning("Player with privileged UUID '{}' FAILED "
+                                    "to authenticate as '{}'"
+                                    "!".format(uuid, account))
+                return False
+        return True
+
+
+    # Helper functions - Used by hooks and commands
+
+    def build_rejection(self, reason):
+        """
+        Function to build packet to reject connection for client.
+
+        :param reason: String. Reason for rejection.
+        :return: Rejection packet.
+        """
+        return build_packet(packets["connect_failure"],
+                            ConnectFailure.build(
+                                dict(reason=reason)))
+


### PR DESCRIPTION
In its current state, StarryPy3k is vulnerable to UUID spoofing attacks. These attacks can be used to easily and effectively gain an Owner rank on most servers.
Since Starbound leaks UUIDs in multiple ways, including some that would be quite hard to block, an alternative method of authentication appears to be necessary.