### PR TITLE
Chat enhancements, formatting, Planet Announcer, etc

### DIFF
--- a/Chat Commands.md
+++ b/Chat Commands.md
@@ -387,6 +387,16 @@ Note: This is old syntax, in that each player has their own spawn planet. It wou
     - **Role:** Registered
     - **Description:** List all planets the player is owner of.
     
+  - /planet_access (arguments...)
+    - **Role:** Registered
+    - **Description:** Manage who is allowed or disallowed access to your claim.
+    - /planet_access (Player Name) (add/remove): Adds or removes a player from the planet's access list.
+    - /planet_access whitelist (true/false): Sets the access list to behave 
+    like a whitelist (only players on the list can access) or a blacklist 
+    (default, everyone except players on the list can access).
+    - /planet_access list: Lists the players on the access list.
+    - /planet_access help: Displays the help in-game.
+     
   - /set_claim_greet (message)
     - **Role:** Registered
     - **Description:** Sets a custom greeting message that is displayed when players beam onto the planet, or clears it if unspecified.

--- a/Chat Commands.md
+++ b/Chat Commands.md
@@ -18,6 +18,8 @@ Note: This document is likely to change often, as well as become outdated quickl
 - /spawn
 - /u
 - /whisper , /w
+- /reply , /r
+- /ignore
 - /who
 - /whoami
 - /p
@@ -35,6 +37,7 @@ Note: This document is likely to change often, as well as become outdated quickl
 - /change_owner
 - /helper_list
 - /list_claims
+- /set_claim_greet
 
 ***Moderator Commands***
 
@@ -63,6 +66,7 @@ Note: This document is likely to change often, as well as become outdated quickl
 - /give , /item , /give_item
 - /set_poi
 - /del_poi
+- /set_greeting
 - /grant , /promote , /revoke , /demote
 
 ***SuperAdmin Commands***
@@ -237,7 +241,7 @@ Note: This is old syntax, in that each player has their own spawn planet. It wou
 #### Chat Manager
 
 - ***Depend on:***
-  - Command Dispatcher, Player Manger
+  - Command Dispatcher, Player Manager
 
 - ***Commands Provided***
   - /mute (username)
@@ -251,7 +255,7 @@ Note: This is old syntax, in that each player has their own spawn planet. It wou
 #### Chat Enhancements
 
 - ***Depend on:***
-  - Command Dispatcher, Player Manger
+  - Command Dispatcher, Player Manager
 
 - ***Commands Provided***
   - /l (message)
@@ -266,15 +270,24 @@ Note: This is old syntax, in that each player has their own spawn planet. It wou
      - **Role:** Guest
      - **Description:** Sends a private message to another user.
      - **Alias:** /w
+     
+  - /reply (message)
+    - **Role:** Guest
+    - **Description:** Sends a private message to the last person to privately message you.
+    - **Alias:** /r
 
   - /p (message)
      - **Role:** Guest
      - **Description:** Sends a message to everyone in your party. If not in a party, defaults to local chat.
+     
+  - /ignore (username)
+    - **Role:** Guest
+    - **Description:** Ignores a player, preventing you from seeing their messages. Run again to remove a player from the ignore list.
 
 #### Emotes
 
 - ***Depend on:***
-  - Command Dispatcher, Player Manger
+  - Command Dispatcher, Player Manager
 
 - ***Commands Provided***
   - /me [emote]
@@ -309,7 +322,7 @@ Note: This is old syntax, in that each player has their own spawn planet. It wou
 #### New Player Greeter
 
 - ***Depend on:***
-  - Command Dispatcher, Player Manger
+  - Command Dispatcher, Player Manager
 
 - ***Commands Provided***
   - None
@@ -317,7 +330,7 @@ Note: This is old syntax, in that each player has their own spawn planet. It wou
 #### Planet Protect
 
 - ***Depend on:***
-  - Command Dispatcher, Player Manger
+  - Command Dispatcher, Player Manager
 
 - ***Commands Provided***
   - /protect
@@ -373,6 +386,11 @@ Note: This is old syntax, in that each player has their own spawn planet. It wou
   - /list_claims
     - **Role:** Registered
     - **Description:** List all planets the player is owner of.
+    
+  - /set_claim_greet (message)
+    - **Role:** Registered
+    - **Description:** Sets a custom greeting message that is displayed when players beam onto the planet, or clears it if unspecified.
+    - Requires Planet Announcer to be installed.
 
   - Note: All of the commands except /claim and /list_helper require the user to be the owner of the planet.
 
@@ -389,6 +407,16 @@ Note: This is old syntax, in that each player has their own spawn planet. It wou
   - /tps [from player] (to player)
     - **Role:** Moderator
     - **Description:** Warps the specified from player, or self if none, to the specified to player's ship.
+    
+#### Planet Announcer
+
+- ***Depend on:***
+  - Command Dispatcher, Player Manager
+  
+- ***Commands Provided***
+  - /set_greeting (message)
+    - **Role:** Admin
+    - **Description:** Sets a custom greeting message that is displayed when players beam onto the planet, or clears it if unspecified.
 
 #### Planet Backups
 

--- a/plugins/chat_enhancements.py
+++ b/plugins/chat_enhancements.py
@@ -204,14 +204,18 @@ class ChatEnhancements(StorageCommandPlugin):
             yield from self._send_to_server(data,
                                             ChatSendMode.UNIVERSE,
                                             connection)
-            try:
+            if link_plugin_if_available(self, "irc_bot"):
                 # Try sending it to IRC if we have that available.
                 asyncio.ensure_future(
                     self.plugins["irc_bot"].bot_write(
                         "<{}> {}".format(connection.player.alias,
                                          " ".join(data))))
-            except KeyError:
-                pass
+            if link_plugin_if_available(self, "discord_bot"):
+                discord = self.plugins['discord_bot']
+                asyncio.ensure_future(discord.bot.send_message(
+                    discord.bot.get_channel(discord.channel),
+                    "**<{}>** {}".format(connection.player.alias, " ".join(
+                        data))))
             return True
 
     @Command("p",

--- a/plugins/claims.py
+++ b/plugins/claims.py
@@ -10,7 +10,7 @@ Author: medeor413
 import asyncio
 
 from base_plugin import StorageCommandPlugin
-from plugins.player_manager import Registered, Planet
+from plugins.player_manager import Registered, Admin
 from utilities import Command, send_message, link_plugin_if_available
 
 
@@ -34,7 +34,10 @@ class Claims(StorageCommandPlugin):
         if link_plugin_if_available(self, "planet_announcer"):
             self.planet_announcer = self.plugins["planet_announcer"]
 
-    def is_owner(self, uuid, location):
+    def is_owner(self, connection, location):
+        uuid = connection.player.uuid
+        if connection.player.check_role(Admin):
+            return True
         if uuid not in self.storage["owners"]:
             return False
         elif str(location) not in self.storage["owners"][uuid]:
@@ -139,7 +142,7 @@ class Claims(StorageCommandPlugin):
         uuid = connection.player.uuid
         if not self.planet_protect.check_protection(location):
             send_message(connection, "This planet is not protected.")
-        elif not self.is_owner(uuid, location):
+        elif not self.is_owner(connection, location):
             send_message(connection, "You don't own this planet!")
         elif location.locationtype() is "ShipWorld":
             send_message(connection, "Can't unclaim your ship!")
@@ -162,7 +165,7 @@ class Claims(StorageCommandPlugin):
         if not self.planet_protect.check_protection(location):
             send_message(connection, "This location is not protected.")
         if target is not None:
-            if not self.is_owner(uuid, location):
+            if not self.is_owner(connection, location):
                 send_message(connection, "You don't own this planet!")
             else:
                 protection = self.planet_protect.get_protection(location)
@@ -193,7 +196,7 @@ class Claims(StorageCommandPlugin):
         if not self.planet_protect.check_protection(location):
             send_message(connection, "This location is not protected.")
         if target is not None:
-            if not self.is_owner(uuid, location):
+            if not self.is_owner(connection, location):
                 send_message(connection, "You don't own this planet!")
             elif str.lower(target.alias) == str.lower(alias):
                 send_message(connection, "Can't remove yourself from the build"
@@ -216,7 +219,7 @@ class Claims(StorageCommandPlugin):
         location = connection.player.location
         if not self.planet_protect.check_protection(location):
             send_message(connection, "This location is not protected.")
-        elif not self.is_owner(uuid, location):
+        elif not self.is_owner(connection, location):
             send_message(connection, "You don't own this planet!")
         else:
             protection = self.planet_protect.get_protection(location)
@@ -235,7 +238,7 @@ class Claims(StorageCommandPlugin):
         if not self.planet_protect.check_protection(location):
             send_message(connection, "This location is not protected.")
         if target is not None:
-            if not self.is_owner(uuid, location):
+            if not self.is_owner(connection, location):
                 send_message(connection, "You don't own this planet!")
             elif location.locationtype() is "ShipWorld":
                 send_message(connection, "Can't transfer ownership of your "
@@ -291,7 +294,7 @@ class Claims(StorageCommandPlugin):
         location = str(connection.player.location)
         msg = " ".join(data)
         if self.planet_announcer:
-            if self.is_owner(connection.player.uuid, location):
+            if self.is_owner(connection, location):
                 if not msg:
                     if location in self.planet_announcer.storage["greetings"]:
                         self.planet_announcer.storage["greetings"].pop(

--- a/plugins/claims.py
+++ b/plugins/claims.py
@@ -30,16 +30,6 @@ class Claims(StorageCommandPlugin):
             self.storage["owners"] = {}
         self.max_claims = self.config.get_plugin_config(self.name)[
             "max_claims_per_person"]
-        # Convert alias entries to uuid entries
-        to_convert = {}
-        for alias in self.storage["owners"].keys():
-            player = self.plugins["player_manager"].get_player_by_alias(alias)
-            if player:
-                to_convert[alias] = player.uuid
-        if to_convert:
-            for alias, uuid in to_convert.items():
-                self.storage["owners"][uuid] = self.storage["owners"].pop(alias)
-
 
     def is_owner(self, uuid, location):
         if uuid not in self.storage["owners"]:

--- a/plugins/discord_bot.py
+++ b/plugins/discord_bot.py
@@ -208,14 +208,14 @@ class DiscordPlugin(BasePlugin):
                 for emote in server.emojis:
                     text = text.replace("<:{}:{}>".format(emote.name,emote.id),
                                         ":{}:".format(emote.name))
-                yield from cls.factory.broadcast("<^orange;Discord^reset;> <{}> {}"
-                                                 "".format(nick, text),
+                yield from cls.factory.broadcast("[^orange;Discord^reset;]<{}>"
+                                                 " {}".format(nick, text),
                                                  mode=ChatReceiveMode.BROADCAST)
                 if cls.config.get_plugin_config(cls.name)["log_discord"]:
                     cls.logger.info("<{}> {}".format(nick, text))
                 if link_plugin_if_available(cls, "irc_bot"):
                     asyncio.ensure_future(cls.plugins['irc_bot'].bot_write(
-                                          "<DC><{}> {}".format(nick, text)))
+                                          "[DC]<{}> {}".format(nick, text)))
 
     @asyncio.coroutine
     def make_announce(self, connection, circumstance):
@@ -227,7 +227,7 @@ class DiscordPlugin(BasePlugin):
         :return: Null.
         """
         yield from asyncio.sleep(1)
-        yield from self.bot_write("{} has {} the server.".format(
+        yield from self.bot_write("**{}** has {} the server.".format(
             connection.player.alias, circumstance))
 
     @asyncio.coroutine

--- a/plugins/discord_bot.py
+++ b/plugins/discord_bot.py
@@ -216,14 +216,14 @@ class DiscordPlugin(BasePlugin):
                 for emote in server.emojis:
                     text = text.replace("<:{}:{}>".format(emote.name,emote.id),
                                         ":{}:".format(emote.name))
-                yield from cls.factory.broadcast("[^orange;DC^reset;]<{}>"
+                yield from cls.factory.broadcast("[^orange;DC^reset;] <{}>"
                                                  " {}".format(nick, text),
                                                  mode=ChatReceiveMode.BROADCAST)
                 if cls.config.get_plugin_config(cls.name)["log_discord"]:
                     cls.logger.info("<{}> {}".format(nick, text))
                 if cls.irc_bot_exists:
                     asyncio.ensure_future(cls.plugins['irc_bot'].bot_write(
-                                          "[DC]<{}> {}".format(nick, text)))
+                                          "[DC] <{}> {}".format(nick, text)))
 
     @asyncio.coroutine
     def make_announce(self, connection, circumstance):

--- a/plugins/discord_bot.py
+++ b/plugins/discord_bot.py
@@ -91,6 +91,7 @@ class DiscordPlugin(BasePlugin):
     client_id = None
     connection = None
     dispatcher = None
+    irc_bot_exists = None
 
     def __init__(self):
         super().__init__()
@@ -113,6 +114,8 @@ class DiscordPlugin(BasePlugin):
         DiscordPlugin.connection = self.connection
         self.dispatcher = self.plugins.command_dispatcher
         DiscordPlugin.dispatcher = self.dispatcher
+        self.irc_bot_exists = link_plugin_if_available(self, 'irc_bot')
+        DiscordPlugin.irc_bot_exists = self.irc_bot_exists
         self.prefix = self.config.get_plugin_config("command_dispatcher")[
             "command_prefix"]
         self.token = self.config.get_plugin_config(self.name)["token"]
@@ -218,7 +221,7 @@ class DiscordPlugin(BasePlugin):
                                                  mode=ChatReceiveMode.BROADCAST)
                 if cls.config.get_plugin_config(cls.name)["log_discord"]:
                     cls.logger.info("<{}> {}".format(nick, text))
-                if link_plugin_if_available(cls, "irc_bot"):
+                if cls.irc_bot_exists:
                     asyncio.ensure_future(cls.plugins['irc_bot'].bot_write(
                                           "[DC]<{}> {}".format(nick, text)))
 
@@ -236,7 +239,7 @@ class DiscordPlugin(BasePlugin):
             connection.player.alias, circumstance))
 
     @asyncio.coroutine
-    def handle_command(data):
+    def handle_command(self, data):
         split = data.split()
         command = split[0]
         to_parse = split[1:]

--- a/plugins/irc_bot.py
+++ b/plugins/irc_bot.py
@@ -304,9 +304,9 @@ class IRCPlugin(BasePlugin):
                 self.logger.info("<" + nick + "> " + message)
             if self.discord_active:
                 discord = self.plugins['discord_bot']
-                asyncio.ensure_future(discord.bot_write("<IRC> **<{}>** {}"
+                asyncio.ensure_future(discord.bot_write("[IRC]**<{}>** {}"
                                                         .format(nick, message)))
-            yield from self.factory.broadcast("< ^orange;IRC^reset; > <{}> "
+            yield from self.factory.broadcast("[^orange;IRC^reset;] <{}> "
                                           "{}".format(nick, message),
                                               mode=ChatReceiveMode.BROADCAST)
 

--- a/plugins/irc_bot.py
+++ b/plugins/irc_bot.py
@@ -307,7 +307,7 @@ class IRCPlugin(BasePlugin):
                 self.logger.info("<" + nick + "> " + message)
             if self.discord_active:
                 discord = self.plugins['discord_bot']
-                asyncio.ensure_future(discord.bot_write("[IRC]**<{}>** {}"
+                asyncio.ensure_future(discord.bot_write("[IRC] **<{}>** {}"
                                                         .format(nick, message)))
             yield from self.factory.broadcast("[^orange;IRC^reset;] <{}> "
                                           "{}".format(nick, message),

--- a/plugins/planet_announcer.py
+++ b/plugins/planet_announcer.py
@@ -57,7 +57,7 @@ class PlanetAnnouncer(StorageCommandPlugin):
         msg = " ".join(data)
         if not msg:
             if location in self.storage["greetings"]:
-                self.storage["greetings"][location].pop()
+                self.storage["greetings"].pop(location)
                 yield from send_message(connection, "Greeting message "
                                                     "cleared.")
         else:

--- a/plugins/planet_announcer.py
+++ b/plugins/planet_announcer.py
@@ -1,0 +1,66 @@
+"""
+StarryPy Planet Announcer Plugin
+
+Announces to all players on a world when another player enters the world.
+Allows Admins to set a custom greeting message on a world.
+
+Reimplemented for StarryPy3k by medeor413.
+"""
+
+import asyncio
+
+from base_plugin import StorageCommandPlugin
+from plugins.player_manager import Admin
+from utilities import send_message, Command
+
+
+class PlanetAnnouncer(StorageCommandPlugin):
+    name = "planet_announcer"
+    depends = ["player_manager", "command_dispatcher"]
+
+    def __init__(self):
+        super().__init__()
+
+    def activate(self):
+        super().activate()
+        if "greetings" not in self.storage:
+            self.storage["greetings"] = {}
+
+    def on_world_start(self, data, connection):
+        asyncio.ensure_future(self._announce(connection))
+        return True
+
+    @asyncio.coroutine
+    def _announce(self, connection):
+        """
+        Announce to all players in the world when a new player beams in,
+        and display the greeting message to the new player, if set.
+
+        :param connection: The connection of the player beaming in.
+        :return: Null.
+        """
+        yield from asyncio.sleep(.5)
+        location = str(connection.player.location)
+        for p in self.factory.connections:
+            if str(p.player.location) == location and p != connection:
+                send_message(p, "{} has beamed down to the planet!".format(
+                    connection.player.alias))
+        if location in self.storage["greetings"]:
+            send_message(connection, self.storage["greetings"][location])
+
+    @Command("set_greeting",
+             role=Admin,
+             doc="Sets the greeting message to be displayed when a player "
+                 "enters this planet, or clears it if unspecified.")
+    def _set_greeting(self, data, connection):
+        location = str(connection.player.location)
+        msg = " ".join(data)
+        if not msg:
+            if location in self.storage["greetings"]:
+                self.storage["greetings"][location].pop()
+                yield from send_message(connection, "Greeting message "
+                                                    "cleared.")
+        else:
+            self.storage["greetings"][location] = msg
+            yield from send_message(connection, "Greeting message set to \"{}"
+                                                "\".".format(msg))

--- a/plugins/player_manager.py
+++ b/plugins/player_manager.py
@@ -721,24 +721,20 @@ class PlayerManager(SimpleCommandPlugin):
                 if not check_logged_in or player.logged_in:
                     return player
 
-    def get_player_by_client_id(self, id, check_logged_in=False) -> Player:
+    def get_player_by_client_id(self, id) -> Player:
         """
-        Grab a hook to a player by their client id. Return Boolean value if
-        only checking login status. Returns player object otherwise.
+        Grab a hook to a player by their client id. Returns player object.
 
         :param id: Integer: Client Id of the player to check.
-        :param check_logged_in: Boolean: Whether we just want login status
-                                (true), or the player's server object (false).
-        :return: Mixed: Boolean on logged_in check, player object otherwise.
+        :return: Player object.
         """
         try:
             iid = int(id)
         except ValueError:
             return
         for player in self.shelf["players"].values():
-            if player.client_id == iid:
-                if not check_logged_in or player.logged_in:
-                    return player
+            if player.client_id == iid and player.logged_in:
+                return player
 
     def find_player(self, search, check_logged_in=False):
         """
@@ -755,7 +751,7 @@ class PlayerManager(SimpleCommandPlugin):
         player = self.get_player_by_name(search, check_logged_in)
         if player is not None:
             return player
-        player = self.get_player_by_client_id(search, check_logged_in)
+        player = self.get_player_by_client_id(search)
         if player is not None:
             return player
 

--- a/plugins/player_manager.py
+++ b/plugins/player_manager.py
@@ -731,7 +731,10 @@ class PlayerManager(SimpleCommandPlugin):
                                 (true), or the player's server object (false).
         :return: Mixed: Boolean on logged_in check, player object otherwise.
         """
-        iid = int(id)
+        try:
+            iid = int(id)
+        except ValueError:
+            return
         for player in self.shelf["players"].values():
             if player.client_id == iid:
                 if not check_logged_in or player.logged_in:

--- a/plugins/poi.py
+++ b/plugins/poi.py
@@ -90,7 +90,7 @@ class POI(StorageCommandPlugin):
             return
         planet = connection.player.location
         poi = " ".join(data).lower()
-        if planet.locationtype() != "ShipWorld" or planet.uuid.decode("utf-8")\
+        if planet.locationtype() != "ShipWorld" or str(planet.uuid, "utf-8") \
                 != connection.player.uuid:
             send_message(connection,
                          "You must be on your ship for this to work.")

--- a/plugins/privileged_chatter.py
+++ b/plugins/privileged_chatter.py
@@ -42,6 +42,8 @@ class PrivilegedChatter(SimpleCommandPlugin):
             "modchat_color"]
         self.report_prefix = self.config.get_plugin_config(self.name)[
             "report_prefix"]
+        self.broadcast_prefix = self.config.get_plugin_config(self.name)[
+            "broadcast_prefix"]
 
     # Commands - In-game actions that can be performed
 
@@ -115,5 +117,5 @@ class PrivilegedChatter(SimpleCommandPlugin):
         :return: Null.
         """
         if data:
-            message = " ".join(data)
+            message = self.broadcast_prefix + " ".join(data)
             broadcast(self, message)

--- a/plugins/spawn.py
+++ b/plugins/spawn.py
@@ -75,7 +75,7 @@ class Spawn(StorageCommandPlugin):
         # TODO - Or maybe not - when player already above spawn planet,
         # nothing happens. It would be nice to generate an alert on this case.
         planet = connection.player.location
-        if planet.locationtype() != "ShipWorld" or planet.uuid.decode("utf-8")\
+        if planet.locationtype() != "ShipWorld" or str(planet.uuid, "utf-8") \
                 != connection.player.uuid:
             send_message(connection,
                          "You must be on your ship for this to work.")


### PR DESCRIPTION
- Add Planet Announcer plugin: Planet Announcer announces to everyone on a planet when a new player beams down, and allows Admins to set custom greeting messages on a planet.
- Claims: Allow claim owners to set custom greeting messages on their planet if Planet Announcer is installed.
- Claims: Add /planet_access: /planet_access allows claim owners to control access to their planet with a black- or whitelist.
- Claims: Remove alias to UUID conversion; should be done on all servers by now.
- Claims: Admins are treated as claim owners for all planets
- Chat Enhancements: Add /reply (/r) command: Sends a whisper to the last person who whispered you.
- Chat enhancements: Add /ignore command: Allows players to choose not to receive messages from another player.
- Discord: Echo /u to Discord
- Discord: Bold joining/leaving players' names
- Discord: Only link IRC Bot once
- IRC/Discord: Use brackets on IRC/Discord tag
- IRC/Discord: Don't send muted players' messages to Discord/IRC
- Spawn, POI: Fix ship detection
- Privileged Chatter: Restore prefix to /broadcast
- Player Manager: Catch ValueError in get_player_by_client_id
- Player Manager: Only return logged in players with get_player_by_client_id