### PR TITLE
Address possible wrapper escape introduced by basic_auth.

### DIFF
--- a/plugins/basic_auth.py
+++ b/plugins/basic_auth.py
@@ -58,9 +58,15 @@ class BasicAuth(SimpleCommandPlugin):
         if not self.enabled:
             return True
         uuid = data["parsed"]["uuid"].decode("ascii")
-        account = data["parsed"]["account"][0]
-        # Why [0]? Because 'account' is a StringSet.
-        # ...but it never contains more than one string.
+        try:
+            account = data["parsed"]["account"][0]
+            # Why [0]? Because 'account' is a StringSet.
+            # ...but it never contains more than one string.
+        except:
+            # Except sometimes account is empty...
+            # I'm not entirely sure why this is, so please feel free to explore.
+            account = ''
+            #self.logger.debug(data)
         player = self.plugins["player_manager"].get_player_by_uuid(uuid)
         # We're only interested in players who already exist.
         if player:


### PR DESCRIPTION
Very rarely, the 'account' field will be completely empty, causing basic_auth to throw an exception. This appears to break StarryPy3k's initial fingerprinting, leading to a possible wrapper escape.

This fix has been tested in production for a few days now and has processed 1,000+ logins without issue.