### PR TITLE
Improvements to Planet Protect, misc. bug fixes

### DIFF
--- a/data_parser.py
+++ b/data_parser.py
@@ -769,10 +769,24 @@ class EntityInteract(Struct):
     target_y = BFloat32
     request_id = UUID
 
+class EntityMessage(Struct):
+    """packet type: 51"""
+    unknown = Byte
+    target_id = SBInt32
+    message_name = StarString
+    message_args = VariantVariant
+    message_uuid = UUID
+    unknown_2 = UBInt16 # Also appears to always be 0
+
+class EntityMessageResponse(Struct):
+    success_level = Byte # 1 is a failure, 2 is a success
+    response = Variant
+    message_uuid = UUID
 
 class StepUpdate(Struct):
     """packet type: 54"""
     heartbeat = VLQ
+
 
 
 class BasePacket(Struct):

--- a/data_parser.py
+++ b/data_parser.py
@@ -771,8 +771,11 @@ class EntityInteract(Struct):
 
 class EntityMessage(Struct):
     """packet type: 51"""
-    unknown = Byte
-    target_id = SBInt32
+    target_unique = Flag
+    if target_unique:
+        unique_id = StarString
+    else:
+        target_id = SBInt32
     message_name = StarString
     message_args = VariantVariant
     message_uuid = UUID

--- a/plugins/claims.py
+++ b/plugins/claims.py
@@ -357,11 +357,11 @@ class Claims(StorageCommandPlugin):
             allow = "disallowed"
             if access["whitelist"]:
                 allow = "allowed"
-            if not data[0]:
+            if not data:
                 yield from send_message(connection, "Argument not recognized. "
                                                     "Usage: /planet_access ["
                                                     "name] add/remove")
-            if data[0].lower() == "whitelist":
+            elif data[0].lower() == "whitelist":
                 if data[1].lower() == "true":
                     access["whitelist"] = True
                     access["list"] = [uuid]

--- a/plugins/claims.py
+++ b/plugins/claims.py
@@ -180,10 +180,10 @@ class Claims(StorageCommandPlugin):
             send_message(connection, "Unclaimed planet {} "
                                      "successfully.".format(location))
 
-    @Command("add_helper",
+    @Command("add_builder",
              role=Registered,
              doc="Add someone to the protected list of your planet.")
-    def _add_helper(self, data, connection):
+    def _add_builder(self, data, connection):
         location = connection.player.location
         alias = connection.player.alias
         uuid = connection.player.uuid
@@ -211,10 +211,10 @@ class Claims(StorageCommandPlugin):
             send_message(connection, "Player {} could not be found."
                          .format(" ".join(data)))
 
-    @Command("rm_helper",
+    @Command("del_builder",
              role=Registered,
              doc="Remove someone from the protected list of your planet.")
-    def _rm_helper(self, data, connection):
+    def _del_builder(self, data, connection):
         location = connection.player.location
         alias = connection.player.alias
         uuid = connection.player.uuid
@@ -237,10 +237,10 @@ class Claims(StorageCommandPlugin):
             send_message(connection, "Player {} could not be found."
                          .format(" ".join(data)))
 
-    @Command("helper_list",
+    @Command("list_builders",
              role=Registered,
              doc="List all of the people allowed to build on this planet.")
-    def _helper_list(self, data, connection):
+    def _list_builders(self, data, connection):
         uuid = connection.player.uuid
         location = connection.player.location
         if not self.planet_protect.check_protection(location):
@@ -249,7 +249,9 @@ class Claims(StorageCommandPlugin):
             send_message(connection, "You don't own this planet!")
         else:
             protection = self.planet_protect.get_protection(location)
-            players = ", ".join(protection.get_builders())
+            uuids = protection.get_builders()
+            players = ", ".join([self.plugins['player_manager']
+                                .get_player_by_uuid(x).alias for x in uuids])
             send_message(connection,
                          "Players allowed to build at location '{}': {}"
                          "".format(connection.player.location, players))
@@ -312,11 +314,11 @@ class Claims(StorageCommandPlugin):
         else:
             send_message(connection, "You haven't claimed any worlds.")
 
-    @Command("set_claim_greet",
+    @Command("set_greeting",
              role=Registered,
              doc="Sets a custom greeting message for the planet, or clears "
                  "it if unspecified.")
-    def _set_claim_greet(self, data, connection):
+    def _set_greeting(self, data, connection):
         location = str(connection.player.location)
         msg = " ".join(data)
         if self.planet_announcer:

--- a/plugins/command_dispatcher.py
+++ b/plugins/command_dispatcher.py
@@ -93,8 +93,17 @@ class CommandDispatcher(BasePlugin):
                 self.register(fn, alias)
 
         if name in self.commands:
-            if fn.priority >= self.commands[name].priority:
+            oldfn = self.commands[name]
+            if fn.priority >= oldfn.priority:
                 self.commands[name] = fn
+                self.logger.debug("Command {} from {} overrides command {} "
+                                  "from {}.".format(name, fn.__self__, name,
+                                                    oldfn.__self__))
+            else:
+                self.logger.debug("Command {} from {} overrides command {} "
+                                  "from {}.".format(name, oldfn.__self__, name,
+                                                    fn.__self__))
+
         else:
             self.commands[name] = fn
 

--- a/plugins/command_dispatcher.py
+++ b/plugins/command_dispatcher.py
@@ -93,10 +93,10 @@ class CommandDispatcher(BasePlugin):
                 self.register(fn, alias)
 
         if name in self.commands:
-            self.logger.info("Got duplicate command name")
-            raise NameError("A command is already registered with the name: "
-                            "{}".format(name))
-        self.commands[name] = fn
+            if fn.priority >= self.commands[name].priority:
+                self.commands[name] = fn
+        else:
+            self.commands[name] = fn
 
     def _send_syntax_error(self, command, error, connection):
         """

--- a/plugins/discord_bot.py
+++ b/plugins/discord_bot.py
@@ -211,7 +211,7 @@ class DiscordPlugin(BasePlugin):
         server = message.server
         if message.author.id != cls.client_id:
             if message.content[0] == ".":
-                asyncio.ensure_future(cls.handle_command(message.content[1:]))
+                asyncio.ensure_future(cls.handle_command(cls, message.content[1:]))
             else:
                 for emote in server.emojis:
                     text = text.replace("<:{}:{}>".format(emote.name,emote.id),

--- a/plugins/discord_bot.py
+++ b/plugins/discord_bot.py
@@ -16,8 +16,6 @@ from base_plugin import BasePlugin
 from plugins.player_manager import Owner, Guest
 from utilities import ChatSendMode, ChatReceiveMode, link_plugin_if_available
 
-bot = discord.Client()
-
 
 # Roles
 
@@ -65,20 +63,14 @@ class MockConnection:
     @asyncio.coroutine
     def send_message(self, *messages):
         for message in messages:
+            if self.owner.irc_bot_exists:
+                asyncio.ensure_future(self.owner.plugins['irc_bot'].bot_write(
+                    message))
             yield from self.owner.bot_write(message)
         return None
 
-# Discord listener
 
-@bot.event
-@asyncio.coroutine
-def on_message(message):
-    yield from DiscordPlugin.send_to_game(message)
-
-
-###
-
-class DiscordPlugin(BasePlugin):
+class DiscordPlugin(BasePlugin, discord.Client):
     name = "discord_bot"
     depends = ['command_dispatcher']
     default_config = {
@@ -88,34 +80,26 @@ class DiscordPlugin(BasePlugin):
         "strip_colors": True,
         "log_discord": False
     }
-    client_id = None
-    connection = None
-    dispatcher = None
-    irc_bot_exists = None
 
     def __init__(self):
-        super().__init__()
+        BasePlugin.__init__(self)
+        discord.Client.__init__(self)
         self.token = None
         self.channel = None
         self.token = None
-        self.connection = None
+        self.client_id = None
+        self.mock_connection = None
         self.prefix = None
         self.dispatcher = None
-        self.bot = bot
         self.color_strip = re.compile("\^(.*?);")
         self.sc = None
         self.irc_bot_exists = False
-        self.irc_bot = None
         self.chat_manager = None
 
     def activate(self):
-        super().activate()
-        self.connection = MockConnection(self)
-        DiscordPlugin.connection = self.connection
+        BasePlugin.activate(self)
         self.dispatcher = self.plugins.command_dispatcher
-        DiscordPlugin.dispatcher = self.dispatcher
         self.irc_bot_exists = link_plugin_if_available(self, 'irc_bot')
-        DiscordPlugin.irc_bot_exists = self.irc_bot_exists
         self.prefix = self.config.get_plugin_config("command_dispatcher")[
             "command_prefix"]
         self.token = self.config.get_plugin_config(self.name)["token"]
@@ -124,6 +108,7 @@ class DiscordPlugin(BasePlugin):
         self.sc = self.config.get_plugin_config(self.name)["strip_colors"]
         asyncio.ensure_future(self.start_bot())
         self.update_id(self.client_id)
+        self.mock_connection = MockConnection(self)
         if link_plugin_if_available(self, "chat_manager"):
             self.chat_manager = self.plugins['chat_manager']
 
@@ -171,8 +156,9 @@ class DiscordPlugin(BasePlugin):
             if data["parsed"]["send_mode"] == ChatSendMode.UNIVERSE:
                 if self.chat_manager:
                     if not self.chat_manager.mute_check(connection.player):
+                        alias = connection.player.alias
                         asyncio.ensure_future(self.bot_write("**<{}>** {}"
-                                                             .format(connection.player.alias,
+                                                             .format(alias,
                                                                      msg)))
         return True
 
@@ -187,18 +173,20 @@ class DiscordPlugin(BasePlugin):
         """
         self.logger.info("Starting Discord Bot")
         try:
-            yield from bot.login(self.token, loop=self.loop)
-            yield from bot.connect()
+            yield from self.login(self.token, loop=self.loop)
+            yield from self.connect()
         except Exception as e:
             self.logger.exception(e)
 
-    @classmethod
-    def update_id(cls, client_id):
-        cls.client_id = client_id
+    def update_id(self, client_id):
+        self.client_id = client_id
 
-    @classmethod
     @asyncio.coroutine
-    def send_to_game(cls, message):
+    def on_message(self, message):
+        yield from self.send_to_game(message)
+
+    @asyncio.coroutine
+    def send_to_game(self, message):
         """
         Broadcast a message on the server. Make sure it isn't coming from the
         bot (or else we get duplicate messages).
@@ -209,20 +197,22 @@ class DiscordPlugin(BasePlugin):
         nick = message.author.display_name
         text = message.clean_content
         server = message.server
-        if message.author.id != cls.client_id:
+        if message.author.id != self.client_id:
             if message.content[0] == ".":
-                asyncio.ensure_future(cls.handle_command(cls, message.content[1:]))
+                asyncio.ensure_future(self.handle_command(message.content[
+                                                          1:], nick))
             else:
                 for emote in server.emojis:
-                    text = text.replace("<:{}:{}>".format(emote.name,emote.id),
+                    text = text.replace("<:{}:{}>".format(emote.name,
+                                                          emote.id),
                                         ":{}:".format(emote.name))
-                yield from cls.factory.broadcast("[^orange;DC^reset;] <{}>"
-                                                 " {}".format(nick, text),
-                                                 mode=ChatReceiveMode.BROADCAST)
-                if cls.config.get_plugin_config(cls.name)["log_discord"]:
-                    cls.logger.info("<{}> {}".format(nick, text))
-                if cls.irc_bot_exists:
-                    asyncio.ensure_future(cls.plugins['irc_bot'].bot_write(
+                yield from self.factory.broadcast("[^orange;DC^reset;] <{}>"
+                                                  " {}".format(nick, text),
+                                                  mode=ChatReceiveMode.BROADCAST)
+                if self.config.get_plugin_config(self.name)["log_discord"]:
+                    self.logger.info("<{}> {}".format(nick, text))
+                if self.irc_bot_exists:
+                    asyncio.ensure_future(self.plugins['irc_bot'].bot_write(
                                           "[DC] <{}> {}".format(nick, text)))
 
     @asyncio.coroutine
@@ -239,16 +229,21 @@ class DiscordPlugin(BasePlugin):
             connection.player.alias, circumstance))
 
     @asyncio.coroutine
-    def handle_command(self, data):
+    def handle_command(self, data, user):
         split = data.split()
         command = split[0]
         to_parse = split[1:]
-        DiscordPlugin.connection.player.roles = DiscordPlugin.connection.player.guest
-        if command in DiscordPlugin.dispatcher.commands:
+        self.mock_connection.player.roles = \
+            self.mock_connection.player.guest
+        if command in self.dispatcher.commands:
             # Only handle commands that work from Discord
             if command in ('who', 'help'):
-                yield from DiscordPlugin.dispatcher.run_command(command,
-                                                       DiscordPlugin.connection,
+                if self.irc_bot_exists:
+                    asyncio.ensure_future(self.plugins['irc_bot'].bot_write(
+                        "[DC] <{}> .{}".format(user, " ".join(split))
+                    ))
+                yield from self.dispatcher.run_command(command,
+                                                       self.mock_connection,
                                                        to_parse)
         else:
             yield from self.bot_write("Command not found.")
@@ -256,5 +251,5 @@ class DiscordPlugin(BasePlugin):
     @asyncio.coroutine
     def bot_write(self, msg, target=None):
         if target is None:
-            target = bot.get_channel(self.channel)
-        asyncio.ensure_future(bot.send_message(target, msg))
+            target = self.get_channel(self.channel)
+        asyncio.ensure_future(self.send_message(target, msg))

--- a/plugins/emotes.py
+++ b/plugins/emotes.py
@@ -47,11 +47,16 @@ class Emotes(StorageMixin, SimpleCommandPlugin):
 
     def __init__(self):
         super().__init__()
+        self.irc_active = False
+        self.discord_active = False
+        self.chat_enhancements = False
 
     def activate(self):
         super().activate()
-        link_plugin_if_available(self, "irc_bot")
-        link_plugin_if_available(self, "chat_enhancements")
+        self.irc_active = link_plugin_if_available(self, "irc_bot")
+        self.discord_active = link_plugin_if_available(self, "discord_bot")
+        self.chat_enhancements = link_plugin_if_available(self,
+                                                      "chat_enhancements")
 
     # Helper functions - Used by commands
 
@@ -93,12 +98,14 @@ class Emotes(StorageMixin, SimpleCommandPlugin):
             except KeyError:
                 pass
             finally:
-                try:
+                if self.irc_active:
                     asyncio.ensure_future(
                         self.plugins["irc_bot"].bot_write(" -*- {} {}".format(
                             connection.player.alias, emote)))
-                except KeyError:
-                    pass
+                if self.discord_active:
+                    asyncio.ensure_future(self.plugins["discord_bot"]
+                        .bot_write(" -*- {} {}".format(
+                        connection.player.alias, emote)))
                 message = "^orange;{} {}".format(connection.player.alias,
                                                  emote)
                 try:

--- a/plugins/general_commands.py
+++ b/plugins/general_commands.py
@@ -252,7 +252,7 @@ class GeneralCommands(SimpleCommandPlugin):
         send_message(connection,
                      self.generate_whois(connection.player))
 
-    @Command("here", "planet",
+    @Command("here",
              role=Whoami,
              doc="Displays all players on the same planet as you.")
     def _here(self, data, connection):

--- a/plugins/general_commands.py
+++ b/plugins/general_commands.py
@@ -238,7 +238,7 @@ class GeneralCommands(SimpleCommandPlugin):
             broadcast(connection, "{}'s name has been changed to {}".format(
                 old_alias, clean_alias))
 
-    @Command("whoami",
+    @Command("serverwhoami",
              role=Whoami,
              doc="Displays your current nickname for chat.")
     def _whoami(self, data, connection):
@@ -249,8 +249,6 @@ class GeneralCommands(SimpleCommandPlugin):
         :param connection: The connection from which the packet came.
         :return: Null.
         """
-        # TODO: currently this is buggy, and will sometime not work...
-        # instead, the Starbound version of /whoami will take over.
         send_message(connection,
                      self.generate_whois(connection.player))
 

--- a/plugins/planet_protect.py
+++ b/plugins/planet_protect.py
@@ -100,7 +100,7 @@ class PlanetProtect(StorageCommandPlugin):
             return True
         else:
             action = data["parsed"]["spawn_type"]
-            if action not in [EntitySpawnType.OBJECT]:
+            if action not in [EntitySpawnType.OBJECT, EntitySpawnType.VEHICLE]:
                 return True
         yield from self._protection_warn(data, connection)
 

--- a/pparser.py
+++ b/pparser.py
@@ -56,8 +56,8 @@ parse_map = {
     48: None,
     49: None,
     50: None,
-    51: None,
-    52: None,
+    51: EntityMessage,
+    52: EntityMessageResponse,
     53: None,
     54: StepUpdate
 }

--- a/server.py
+++ b/server.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import sys
+import signal
 
 from configuration_manager import ConfigurationManager
 from data_parser import ChatReceived
@@ -310,6 +311,8 @@ if __name__ == "__main__":
     ch.setFormatter(formatter)
     aiologger.addHandler(ch)
     logger.addHandler(ch)
+
+    signal.signal(signal.SIGINT, signal.default_int_handler)
 
     loop = asyncio.get_event_loop()
     loop.set_debug(False)  # Removed in commit to avoid errors.

--- a/utilities.py
+++ b/utilities.py
@@ -347,7 +347,8 @@ class Command:
     interface for all commands, including roles, documentation, usage syntax,
     and aliases.
     """
-    def __init__(self, *aliases, role=None, roles=None, doc=None, syntax=None):
+    def __init__(self, *aliases, role=None, roles=None, doc=None,
+                 syntax=None, priority=0):
         if syntax is None:
             syntax = ()
         if isinstance(syntax, str):
@@ -365,6 +366,7 @@ class Command:
         self.human_syntax = " ".join(syntax)
         self.doc = doc
         self.aliases = aliases
+        self.priority = priority
 
     def __call__(self, f):
         """
@@ -388,6 +390,7 @@ class Command:
         wrapped.__doc__ = self.doc
         wrapped.roles = self.roles
         wrapped.syntax = self.human_syntax
+        wrapped.priority = self.priority
         # f.roles = self.roles
         # f.syntax = self.human_syntax
         # f.__doc__ = self.doc

--- a/utilities.py
+++ b/utilities.py
@@ -89,9 +89,14 @@ class EntityInteractionType(IntEnum):
 
 class EntitySpawnType(IntEnum):
     OBJECT = 1
-    THROW_ITEM = 3
-    THROW_POD = 7
+    VEHICLE = 2
+    ITEM_DROP = 3
+    PLANT_DROP = 4
+    PROJECTILE = 5
+    STAGEHAND = 6
+    MONSTER = 7
     NPC = 8
+    PLAYER = 9
 
 
 # Useful things

--- a/utilities.py
+++ b/utilities.py
@@ -88,6 +88,7 @@ class EntityInteractionType(IntEnum):
 
 
 class EntitySpawnType(IntEnum):
+    PLANT = 0
     OBJECT = 1
     VEHICLE = 2
     ITEM_DROP = 3


### PR DESCRIPTION
- Planet Protect: Use UUIDs instead of aliases
- Planet Protect: Disallow vehicle spawning on protected planets
- Claims: Properly handle no arguments in /planet_access
- Claims: Overload Planet Protect commands
- Command Dispatcher: Allow command overloading using priority system
- General Commands: Rename /whoami to /serverwhoami
- General Commands: Remove /planet alias for /here
- Discord Bot: Fix commands not working in Discord
- Discord Bot: Send /me to Discord
- Discord Bot/IRC Bot: Echo commands used to both bots
- Core: Ensure SIGINT handler is set
- Data Parser: Parse entity message packets

NOTE: Claim owners will now manage those allowed to build on their planets using the /add_builder, /del_builder, and /list_builders commands. /add_helper, /rm_helper, /helper_list are no longer available.