### PR TITLE
Permission System Rewrite

### DIFF
--- a/Chat Commands.md
+++ b/Chat Commands.md
@@ -6,7 +6,7 @@ This document seeks to enumerate the commands that are available to the users. S
 
 Note: This document is likely to change often, as well as become outdated quickly, as this software develops. For that, I apologize in advance.
 
-## Commands by User Level
+## Commands by User Level (Default Configuration)
 
 ***Guest Commands***
 
@@ -16,14 +16,15 @@ Note: This document is likely to change often, as well as become outdated quickl
 - /mel
 - /motd
 - /spawn
+- /show_spawn
 - /u
 - /whisper , /w
 - /reply , /r
 - /ignore
 - /who
-- /whoami
+- /serverwhoami
 - /p
-- /here , /planet
+- /here
 - /poi
 - /report
 
@@ -32,12 +33,13 @@ Note: This document is likely to change often, as well as become outdated quickl
 - /nick
 - /claim
 - /unclaim
-- /add_helper
-- /rm_helper
+- /add_builder
+- /rm_builder
 - /change_owner
-- /helper_list
+- /list_builders
 - /list_claims
-- /set_claim_greet
+- /set_greeting
+- /planet_access
 
 ***Moderator Commands***
 
@@ -47,10 +49,9 @@ Note: This document is likely to change often, as well as become outdated quickl
 - /list_bans
 - /mute
 - /set_motd
-- /show_spawn
 - /unmute
 - /modchat , /m
-- /warp , /tp
+- /tp
 - /tps
 
 ***Admin Commands***
@@ -67,12 +68,15 @@ Note: This document is likely to change often, as well as become outdated quickl
 - /set_poi
 - /del_poi
 - /set_greeting
-- /grant , /promote , /revoke , /demote
+- /user
 
 ***SuperAdmin Commands***
 
+- /set_motd
 - /set_spawn
 - /del_player
+- /maintenance_mode
+- /shutdown
 
 ## Commands by Plugin
 
@@ -113,11 +117,11 @@ In-game, the IRC bot does not provide any commands. Instead, it provides a means
 
 - ***Commands Provided***
   - /motd
-     - **Role:** Guest
+     - **Permission:** `motd.motd`
      - **Description:** Shows the Message of the Day.
 
   - /set_motd (message)
-     - **Role:** Moderator
+     - **Permission:** `motd.set_motd`
      - **Description:** Sets the Message of the Day.
 
 #### Spawn
@@ -127,15 +131,15 @@ In-game, the IRC bot does not provide any commands. Instead, it provides a means
 
 - ***Commands Provided***
   - /set_spawn
-     - **Role:** SuperAdmin
+     - **Permission:** `spawn.set_spawn`
      - **Description:** Sets the planet the user is currently standing on as the "spawn" planet.
 
   - /show_spawn
-     - **Role:** Moderator
+     - **Permission:** `spawn.show_spawn`
      - **Description:** Shows the location information of the current "spawn" planet.
 
   - /spawn
-     - **Role:** Guest
+     - **Permission:** `spawn.spawn`
      - **Description:** Move a player's ship to the spawn planet.
      - This command provides free-of-fuel-charge transit from anywhere in the universe.
 
@@ -148,16 +152,16 @@ Note: This is old syntax, in that each player has their own spawn planet. It wou
 
 - ***Commands Provided***
   - /poi [name]
-    - **Role:** Guest
+    - **Permission:** `poi.poi`
     - **Description:** Move a player's ship to the specified POI, or list all POIs if no argument provided.
     - This command does not cost fuel to use, or even require FTL to be enabled.
 
   - /set_poi (name)
-    - **Role:** Admin
+    - **Permission:** `poi.set_poi`
     - **Description:** Sets the planet the user is on as a POI with the specified name.
 
   - /del_poi (name)
-    - **Role:** Admin
+    - **Permission:** `poi.set_poi`
     - **Description:** Removes the specified POI from the POI list.
 
 #### Player Manager
@@ -167,34 +171,46 @@ Note: This is old syntax, in that each player has their own spawn planet. It wou
 
 - ***Commands Provided***
   - /kick (username) [reason]
-     - **Role:** Moderator
-     - **Description:** Kicks a player off the server.
+     - **Permission:** `player_manager.kick`
+     - **Description:** Kicks a player off the server. Fails if the user is 
+     the same or lower rank than the target.
 
   - /ban (username) (reason)
-     - **Role:** Moderator
-     - **Description:** Bans a player from connecting to the server.
+     - **Permission:** `player_manager.ban`
+     - **Description:** Bans a player from connecting to the server. Fails if 
+     the user is the same or lower rank than the target.
 
   - /unban (username)
-     - **Role:** Moderator
+     - **Permission:** `player_manager.ban`
      - **Description:** Unbans a player from connecting to the server.
 
   - /list_bans
-     - **Role:** Moderator
+     - **Permission:** `player_manager.ban`
      - **Description:** Display the current bans in effect.
 
   - /list_players
-     - **Role:** Admin
+     - **Permission:** `player_manager.list_players`
      - **Description:** Lists all players in the player database.
-
-  - /grant (Role) (Username)
-     - **Role:** Admin
-     - **Description:** Grant a role to a player.
-     - **Alias:** /promote
-     - Roles can be either part of the hierarchy (moderator, admin, etc...) or command-specific (/kick, /set_motd, etc...)
+     
+  - /user
+     - **Permission:** `player_manager.user`
+     - **Description:** Manage permissions and ranks.
+     - /user addperm (user) (permission): Adds a permission to a player. 
+     Fails if the user doesn't have the permission.
+     - /user rmperm (player) (permission): Removes a permission from a 
+     player. Fails if the user doesn't have the permission, or if the target's 
+     priority is higher than the user's.
+     - /user addrank (player) (rank): Adds a rank to a player. Fails if the 
+     rank to be added is equal to or greater than the user's highest rank.
+     - /user rmrank (player) (rank): Removes a rank from a player. Fails if 
+     the target outranks or is equal in rank to the user.
+     - /user listperms (player): Lists the permissions a player has.
+     - /user listranks (player): Lists the ranks a player has.
 
   - /del_player (Username) [*force]
-     - **Role:** SuperAdmin
-     - **Description:** Removed a player's entry from the player database.
+     - **Permission:** `player_manager.delete_player`
+     - **Description:** Removes a player's entry from the player database. 
+     Fails if the user is the same or lower rank than the target.
      - In order to remove a player who is currently connected, you must use the *force keyword as well.
 
 #### General Commands
@@ -204,28 +220,39 @@ Note: This is old syntax, in that each player has their own spawn planet. It wou
 
 - ***Commands Provided***
   - /who
-     - **Role:** Guest
+     - **Permission:** `general_commands.who`
      - **Description:** Lists all players currently logged in.
   - /here
-     - **Role:** Guest
+     - **Permission:** `general_commands.who`
      - **Description:** Lists all players on the same planet as the user.
-     - **Alias:** /planet
   - /whois (username)
-     - **Role:** Admin
+     - **Permission:** `general_commands.whois`
      - **Description:** Displays detailed information about a player.
 
-  - /whoami
-     - **Role:** Guest
-     - **Description:** Displays your current chat nickname.
+  - /serverwhoami
+     - **Permission:** `general_commands.whoami`
+     - **Description:** Displays detailed information about yourself.
 
-  - /nick (new username)
-     - **Role:** Registered
-     - **Description:** Change your current chate nickname to something else.
+  - /nick [user to rename](new username)
+     - **Permission:** `general_commands.nick`, `general_commands.nick_others`
+     - **Description:** Change your current chat nickname to something else,
+      or rename another player.
 
   - /give (username) (item name) [quantity]
-     - **Role:** Admin
+     - **Permission:** `general_commands.give_item`
      - **Description:** Give a player (an) item(s) based on asset name. If no quantity is provided, default to 1.
      - **Aliases:** /item , /give_item
+     
+  - /maintenance_mode
+     - **Permission:** `general_commands.maintenance_mode`
+     - **Description:** Toggles maintenance mode. While maintenance mode is 
+     active, new connections without the `general_commands.maintenance_bypass` 
+     permission will be refused.
+     
+  - /shutdown [time]
+     - **Permission:** `general_commands.shutdown`
+     - **Description:** Shuts down the server, after the given time, or five
+      seconds if not specified.
 
 #### Help
 
@@ -234,7 +261,7 @@ Note: This is old syntax, in that each player has their own spawn planet. It wou
 
 - ***Commands Provided***
   - /help [command]
-     - **Role:** Guest
+     - **Permission:** `help.help`
      - **Description:** Command for providing help with commands.
      - When run without an argument, show the player a list of all available commands to them (at their use level).
 
@@ -245,11 +272,11 @@ Note: This is old syntax, in that each player has their own spawn planet. It wou
 
 - ***Commands Provided***
   - /mute (username)
-     - **Role:** Moderator
+     - **Permission:** `chat_manager.mute`
      - **Description:** Mutes a player.
 
   - /unmute (username)
-     - **Role:** Moderator
+     - **Permission:** `chat_manager.mute`
      - **Description:** Unmutes a player.
 
 #### Chat Enhancements
@@ -259,30 +286,29 @@ Note: This is old syntax, in that each player has their own spawn planet. It wou
 
 - ***Commands Provided***
   - /l (message)
-     - **Role:** Guest
      - **Description:** Send a local message.
 
   - /u (message)
-     - **Role:** Guest
      - **Description:** Sends a universal message.
 
   - /whisper (recipient) (message)
-     - **Role:** Guest
+     - **Permission:** `chat_enhancements.whisper`
      - **Description:** Sends a private message to another user.
      - **Alias:** /w
-     
+
+  - /p (message)
+     - **Permission:** Guest
+     - **Description:** Sends a message to everyone in your party. If not in a party, defaults to local chat.
+
   - /reply (message)
-    - **Role:** Guest
+    - **Permission:** `chat_enhancements.whisper`
     - **Description:** Sends a private message to the last person to privately message you.
     - **Alias:** /r
 
-  - /p (message)
-     - **Role:** Guest
-     - **Description:** Sends a message to everyone in your party. If not in a party, defaults to local chat.
-     
   - /ignore (username)
-    - **Role:** Guest
-    - **Description:** Ignores a player, preventing you from seeing their messages. Run again to remove a player from the ignore list.
+    - **Permission:** `chat_enhancements.ignore`
+    - **Description:** Ignores a player, preventing the user from seeing their 
+    messages. Run again to remove a player from the ignore list.
 
 #### Emotes
 
@@ -291,12 +317,12 @@ Note: This is old syntax, in that each player has their own spawn planet. It wou
 
 - ***Commands Provided***
   - /me [emote]
-     - **Role:** Guest
+     - **Permission:** `emotes.emote`
      - **Description:** Performs a text-emote.
      - When this command is performed with no arguments, a list of built-in actions are sent back to the player.
 
   - /mel [emote]
-     - **Role:** Guest
+     - **Permission:** `emotes.emote`
      - **Description:** Performs a text-emote in local chat.
      - When this command is performed with no arguments, a list of built-in actions are sent back to the player.
 
@@ -307,16 +333,16 @@ Note: This is old syntax, in that each player has their own spawn planet. It wou
 
 - ***Commands Provided***
   - /modchat (message)
-    - **Role:** Moderator
+    - **Permission:** `privileged_chatter.modchat`
     - **Description:** Sends a message visible only to other moderators.
     - **Alias:** /m
   
   - /report (message)
-    - **Role:** Guest
+    - **Permission:** `privileged_chatter.report`
     - **Description:** Sends a report message to all online moderators.
 
   - /broadcast (message)
-    - **Role:** Admin
+    - **Permission:** `privileged_chatter.broadcast`
     - **Description:** Broadcasts an admin message to the entire server.
 
 #### New Player Greeter
@@ -334,24 +360,28 @@ Note: This is old syntax, in that each player has their own spawn planet. It wou
 
 - ***Commands Provided***
   - /protect
-     - **Role:** Admin
+     - **Permission:** `planet_protect.protect`
      - **Description:** Makes a planet protected.
 
   - /unprotect
-     - **Role:** Admin
+     - **Permission:** `planet_protect.unprotect`
      - **Description:** Removes a planet's protection.
 
   - /add_builder (username)
-     - **Role:** Admin
+     - **Permission:** `planet_protect.manage_protection`
      - **Description:** Allow a player build-rights on a protected planet.
 
   - /del_builder (username)
-     - **Role:** Admin
+     - **Permission:** `planet_protect.manage_protection`
      - **Description:** Disallow a player's build-rights on a protected planet.
 
   - /list_builders
-     - **Role:** Admin
+     - **Permission:** `planet_protect.manage_protection`
      - **Description:** Show all players allowed to build on a protected planet.
+  
+  - Additional permissions:
+     - `planet_protect.bypass`: Holders of this permission bypass all planet
+      protection.
 
 #### Claims
 
@@ -360,35 +390,35 @@ Note: This is old syntax, in that each player has their own spawn planet. It wou
 
 - ***Commands Provided***
   - /claim
-    - **Role:** Registered
+    - **Permission:** `claims.claim`*
     - **Description:** Claim a planet to be protected.
 
   - /unclaim
-    - **Role:** Registered*
+    - **Permission:** `claims.claim`*
     - **Description:** Unclaim and unprotect the planet you're standing on.
 
-  - /add_helper (username)
-    - **Role:** Registered*
+  - /add_builder (username)
+    - **Permission:** `claims.manage_claims`*
     - **Description:** Add someone to the protected list of your planet.
 
-  - /rm_helper (username)
-    - **Role:** Registered*
+  - /del_builder (username)
+    - **Permission:** `claims.manage_claims`*
     - **Description:** Remove someone from the protected list of your planet.
 
-  - /helper_list
-    - **Role:** Registered*
+  - /list_builders
+    - **Permission:** `claims.manage_claims`*
     - **Description:** List all of the people allowed to build on this planet.
 
   - /change_owner (username)
-    - **Role:** Registered*
+    - **Permission:** `claims.manage_claims`*
     - **Description:** Transfer ownership of the planet to another person.
     
   - /list_claims
-    - **Role:** Registered
+    - **Permission:** `claims.claim`
     - **Description:** List all planets the player is owner of.
     
   - /planet_access (arguments...)
-    - **Role:** Registered
+    - **Permission:** `claims.planet_access`
     - **Description:** Manage who is allowed or disallowed access to your claim.
     - /planet_access (Player Name) (add/remove): Adds or removes a player from the planet's access list.
     - /planet_access whitelist (true/false): Sets the access list to behave 
@@ -397,12 +427,16 @@ Note: This is old syntax, in that each player has their own spawn planet. It wou
     - /planet_access list: Lists the players on the access list.
     - /planet_access help: Displays the help in-game.
      
-  - /set_claim_greet (message)
-    - **Role:** Registered
+  - /set_greeting (message)
+    - **Permission:** `claims.manage_claims`
     - **Description:** Sets a custom greeting message that is displayed when players beam onto the planet, or clears it if unspecified.
     - Requires Planet Announcer to be installed.
 
-  - Note: All of the commands except /claim and /list_helper require the user to be the owner of the planet.
+  - Note: All of the commands except /claim and /list_claims require the user
+   to be the owner of the planet.
+   
+  - Note: /add_builder, /del_builder, and /list_builders override the 
+  identically-named commands in Planet Protect, and function mostly the same.
 
 #### Warp
 
@@ -411,11 +445,11 @@ Note: This is old syntax, in that each player has their own spawn planet. It wou
   
 - ***Commands Provided***
   - /tp [from player] (to player)
-    - **Role:** Moderator
+    - **Permission:** `warp.tp_player`
     - **Description:** Warps the specified from player, or self if none, to the specified to player.
     
   - /tps [from player] (to player)
-    - **Role:** Moderator
+    - **Permission:** `warp.tp_ship`
     - **Description:** Warps the specified from player, or self if none, to the specified to player's ship.
     
 #### Planet Announcer
@@ -425,7 +459,7 @@ Note: This is old syntax, in that each player has their own spawn planet. It wou
   
 - ***Commands Provided***
   - /set_greeting (message)
-    - **Role:** Admin
+    - **Permission:** `planet_announcer.set_greeting`
     - **Description:** Sets a custom greeting message that is displayed when players beam onto the planet, or clears it if unspecified.
 
 #### Planet Backups

--- a/config/permissions.json
+++ b/config/permissions.json
@@ -1,0 +1,91 @@
+{
+  "Owner": {
+    "priority": 100000,
+    "prefix": "^#F7434C;",
+    "inherits": [
+      "SuperAdmin"
+    ],
+    "permissions": [
+      "special.allperms"
+    ]
+  },
+  "SuperAdmin": {
+    "priority": 10000,
+    "prefix": "^#F444A4;",
+    "inherits": [
+      "Admin"
+    ],
+    "permissions": [
+      "player_manager.delete_player",
+      "general_commands.shutdown",
+      "general_commands.maintenance_mode",
+      "motd.set_motd",
+      "spawn.set_spawn"
+    ]
+  },
+  "Admin": {
+    "priority": 1000,
+    "prefix": "^#C443F7;",
+    "inherits": [
+      "Moderator"
+    ],
+    "permissions": [
+      "player_manager.list_players",
+      "planet_protect.bypass",
+      "general_commands.whois",
+      "general_commands.give_item",
+      "planet_announcer.set_greeting",
+      "planet_protect.protect",
+      "planet_protect.manage_protection",
+      "poi.set_poi",
+      "privileged_chatter.broadcast",
+      "warp.tp_player",
+      "warp.tp_ship"
+    ]
+  },
+  "Moderator": {
+    "priority": 100,
+    "prefix": "^#4385F7;",
+    "inherits": [
+      "Registered"
+    ],
+    "permissions": [
+      "player_manager.kick",
+      "player_manager.ban",
+      "player_manager.user",
+      "privileged_chatter.modchat"
+    ]
+  },
+  "Registered": {
+    "priority": 10,
+    "prefix": "^#A0F743;",
+    "inherits": [
+      "Guest"
+    ],
+    "permissions": [
+      "claims.claim",
+      "claims.manage_claims",
+      "claims.planet_access",
+      "general_commands.nick"
+    ]
+  },
+  "Guest": {
+    "priority": 1,
+    "prefix": "^yellow;",
+    "inherits": [],
+    "permissions": [
+      "chat_enhancements.ignore",
+      "emotes.emote",
+      "general_commands.who",
+      "general_commands.here",
+      "general_commands.whoami",
+      "general_commands.uptime",
+      "help.help",
+      "motd.motd",
+      "poi.poi",
+      "privileged_chatter.report",
+      "spawn.spawn",
+      "spawn.show_spawn"
+    ]
+  }
+}

--- a/config/permissions.json.default
+++ b/config/permissions.json.default
@@ -19,6 +19,7 @@
       "player_manager.delete_player",
       "general_commands.shutdown",
       "general_commands.maintenance_mode",
+      "general_commands.maintenance_bypass",
       "motd.set_motd",
       "spawn.set_spawn"
     ]
@@ -32,6 +33,8 @@
     "permissions": [
       "player_manager.list_players",
       "planet_protect.bypass",
+      "general_commands.nick_others",
+      "general_commands.who_clientids",
       "general_commands.whois",
       "general_commands.give_item",
       "planet_announcer.set_greeting",

--- a/config/permissions.json.default
+++ b/config/permissions.json.default
@@ -74,6 +74,7 @@
     "prefix": "^yellow;",
     "inherits": [],
     "permissions": [
+      "chat_enhancements.whisper",
       "chat_enhancements.ignore",
       "emotes.emote",
       "general_commands.who",

--- a/plugins/basic_auth.py
+++ b/plugins/basic_auth.py
@@ -76,7 +76,7 @@ class BasicAuth(SimpleCommandPlugin):
             # eachother, but this is being allowed for the sake of usability.
             if (
                    (
-                        self.plugin_config.owner_rank in player.ranks
+                        self.plugin_config.owner_priority <= player.priority
                         and account == self.plugin_config.owner_sb_account
                    ) or (
                         self.plugin_config.owner_priority > player.priority

--- a/plugins/chat_enhancements.py
+++ b/plugins/chat_enhancements.py
@@ -17,7 +17,7 @@ import data_parser
 import pparser
 import packets
 from base_plugin import StorageCommandPlugin
-from utilities import Command, DotDict, ChatSendMode, ChatReceiveMode, \
+from utilities import Command, ChatSendMode, ChatReceiveMode, \
     send_message, link_plugin_if_available
 
 
@@ -27,15 +27,7 @@ class ChatEnhancements(StorageCommandPlugin):
     name = "chat_enhancements"
     depends = ["player_manager", "command_dispatcher"]
     default_config = {"chat_timestamps": True,
-                      "timestamp_color": "^gray;",
-                      "colors": DotDict({
-                          "Owner": "^#F7434C;",
-                          "SuperAdmin": "^#E23800;",
-                          "Admin": "^#C443F7;",
-                          "Moderator": "^#4385F7;",
-                          "Registered": "^#A0F743;",
-                          "default": "^yellow;"
-                      })}
+                      "timestamp_color": "^gray;"}
 
     def __init__(self):
         super().__init__()
@@ -48,7 +40,6 @@ class ChatEnhancements(StorageCommandPlugin):
     def activate(self):
         super().activate()
         self.command_dispatcher = self.plugins.command_dispatcher.plugin_config
-        self.colors = self.config.get_plugin_config(self.name)["colors"]
         self.cts = self.config.get_plugin_config(self.name)["chat_timestamps"]
         self.cts_color = self.config.get_plugin_config(self.name)[
             "timestamp_color"]
@@ -79,7 +70,7 @@ class ChatEnhancements(StorageCommandPlugin):
                 if connection.player.uuid not in self.storage["ignores"]:
                     self.storage["ignores"][connection.player.uuid] = []
                 if sender.uuid in self.storage["ignores"][
-                    connection.player.uuid]:
+                        connection.player.uuid]:
                     return False
                 try:
                     sender = self.decorate_line(sender.connection)
@@ -128,34 +119,13 @@ class ChatEnhancements(StorageCommandPlugin):
         else:
             timestamp = ""
         try:
-            sender = timestamp + self._colored_name(connection.player)
+            p = connection.player
+            sender = timestamp + p.chat_prefix + p.alias + "^reset;"
         except AttributeError as e:
             self.logger.warning(
                 "AttributeError in colored_name: {}".format(str(e)))
             sender = connection.player.alias
         return sender
-
-    def _colored_name(self, data):
-        """
-        Generate colored name based on target's role.
-
-        :param data: target to check against
-        :return: DotDict. Name of target will be colorized.
-        """
-        if "Owner" in data.roles:
-            color = self.colors.Owner
-        elif "SuperAdmin" in data.roles:
-            color = self.colors.SuperAdmin
-        elif "Admin" in data.roles:
-            color = self.colors.Admin
-        elif "Moderator" in data.roles:
-            color = self.colors.Moderator
-        elif "Registered" in data.roles:
-            color = self.colors.Registered
-        else:
-            color = self.colors.default
-
-        return color + data.alias + "^reset;"
 
     @asyncio.coroutine
     def _send_to_server(self, message, mode, connection):
@@ -268,7 +238,7 @@ class ChatEnhancements(StorageCommandPlugin):
                              .format(recipient.alias))
                 return False
             if recipient.uuid in self.storage["ignores"][
-                connection.player.uuid]:
+                    connection.player.uuid]:
                 send_message(connection, "Cannot send message to player {} "
                                          "as you are currently ignoring "
                                          "them.".format(recipient.alias))
@@ -298,7 +268,7 @@ class ChatEnhancements(StorageCommandPlugin):
                                     "".format(name))
 
     @Command("reply", "r",
-             doc="Send message privately to the last person who privately " \
+             doc="Send message privately to the last person who privately "
                  "messaged you.")
     def _reply(self, data, connection):
         """
@@ -324,7 +294,7 @@ class ChatEnhancements(StorageCommandPlugin):
                              .format(recipient.alias))
                 return False
             if recipient.uuid in self.storage["ignores"][
-                connection.player.uuid]:
+                    connection.player.uuid]:
                 send_message(connection, "Cannot send message to player {} "
                                          "as you are currently ignoring "
                                          "them.".format(recipient.alias))
@@ -353,6 +323,7 @@ class ChatEnhancements(StorageCommandPlugin):
                                     "You haven't been messaged by anyone.")
 
     @Command("ignore",
+             perm="chat_enhancements.ignore",
              doc="Ignores a player, preventing you from seeing their "
                  "messages. Use /ignore again to toggle.")
     def _ignore(self, data, connection):

--- a/plugins/chat_enhancements.py
+++ b/plugins/chat_enhancements.py
@@ -210,6 +210,7 @@ class ChatEnhancements(StorageCommandPlugin):
             return True
 
     @Command("whisper", "w",
+             perm="chat_enhancements.whisper",
              doc="Send message privately to a person.")
     def _whisper(self, data, connection):
         """
@@ -268,6 +269,7 @@ class ChatEnhancements(StorageCommandPlugin):
                                     "".format(name))
 
     @Command("reply", "r",
+             perm="chat_enhancements.whisper",
              doc="Send message privately to the last person who privately "
                  "messaged you.")
     def _reply(self, data, connection):

--- a/plugins/chat_manager.py
+++ b/plugins/chat_manager.py
@@ -84,7 +84,7 @@ class ChatManager(SimpleCommandPlugin):
     # Commands - In-game actions that can be performed
 
     @Command("mute",
-             role=MutePlayer,
+             perm="chat_manager.mute",
              doc="Mutes a user",
              syntax="(username)")
     def _mute(self, data, connection):
@@ -117,7 +117,7 @@ class ChatManager(SimpleCommandPlugin):
                          "{} has muted you.".format(connection.player.alias))
 
     @Command("unmute",
-             role=UnmutePlayer,
+             perm="chat_manager.mute",
              doc="Unmutes a player",
              syntax="(username)")
     def _unmute(self, data, connection):

--- a/plugins/chat_manager.py
+++ b/plugins/chat_manager.py
@@ -105,7 +105,7 @@ class ChatManager(SimpleCommandPlugin):
             send_message(connection,
                          "{} is already muted.".format(player.alias))
             return
-        elif player.check_role(Unmuteable):
+        elif player.priority >= connection.player.priority:
             send_message(connection,
                          "{} is unmuteable.".format(player.alias))
             return

--- a/plugins/claims.py
+++ b/plugins/claims.py
@@ -13,7 +13,6 @@ import packets
 from base_plugin import StorageCommandPlugin
 from data_parser import PlayerWarp
 from pparser import build_packet
-from plugins.player_manager import Registered, Admin
 from utilities import Command, send_message, link_plugin_if_available
 
 
@@ -41,7 +40,8 @@ class Claims(StorageCommandPlugin):
 
     def is_owner(self, connection, location):
         uuid = connection.player.uuid
-        if connection.player.check_role(Admin):
+        if self.plugins.player_manager.perm_check(connection.player,
+                                                  "planet_protect.bypass"):
             return True
         if uuid not in self.storage["owners"]:
             return False
@@ -97,7 +97,8 @@ class Claims(StorageCommandPlugin):
         yield from asyncio.sleep(.5)
         if str(connection.player.location) in self.storage["access"]:
             access = self.storage["access"][str(connection.player.location)]
-            if connection.player.check_role(Admin):
+            if self.plugins.player_manager.perm_check(connection.player,
+                                                      "planet_protect.bypass"):
                 return
             elif connection.player.uuid in access["list"] and not \
                     access["whitelist"]:
@@ -135,7 +136,7 @@ class Claims(StorageCommandPlugin):
             return " ".join(loc)
 
     @Command("claim",
-             role=Registered,
+             perm="claims.claim",
              doc="Claim a planet to be protected.")
     def _claim(self, data, connection):
         location = connection.player.location
@@ -161,7 +162,7 @@ class Claims(StorageCommandPlugin):
                              .format(location))
 
     @Command("unclaim",
-             role=Registered,
+             perm="claims.claim",
              doc="Unclaim and unprotect the planet you're standing on.")
     def _unclaim(self, data, connection):
         location = connection.player.location
@@ -183,6 +184,7 @@ class Claims(StorageCommandPlugin):
     @Command("add_builder",
              role=Registered,
              priority=1,
+             perm="claims.manage_claims",
              doc="Add someone to the protected list of your planet.")
     def _add_builder(self, data, connection):
         location = connection.player.location
@@ -215,6 +217,7 @@ class Claims(StorageCommandPlugin):
     @Command("del_builder",
              role=Registered,
              priority=1,
+             perm="claims.manage_claims",
              doc="Remove someone from the protected list of your planet.")
     def _del_builder(self, data, connection):
         location = connection.player.location
@@ -242,6 +245,7 @@ class Claims(StorageCommandPlugin):
     @Command("list_builders",
              role=Registered,
              priority=1,
+             perm="claims.manage_claims",
              doc="List all of the people allowed to build on this planet.")
     def _list_builders(self, data, connection):
         uuid = connection.player.uuid
@@ -260,7 +264,7 @@ class Claims(StorageCommandPlugin):
                          "".format(connection.player.location, players))
 
     @Command("change_owner",
-             role=Registered,
+             perm="claims.manage_claims",
              doc="Transfer ownership of the planet to another person.")
     def _change_owner(self, data, connection):
         uuid = connection.player.uuid
@@ -306,7 +310,7 @@ class Claims(StorageCommandPlugin):
                          .format(" ".join(data)))
 
     @Command("list_claims",
-             role=Registered,
+             perm="claims.claim",
              doc="List all of the planets you've claimed.")
     def _list_claims(self, data, connection):
         uuid = connection.player.uuid
@@ -320,6 +324,7 @@ class Claims(StorageCommandPlugin):
     @Command("set_greeting",
              role=Registered,
              priority=1,
+             perm="claims.manage_claims",
              doc="Sets a custom greeting message for the planet, or clears "
                  "it if unspecified.")
     def _set_greeting(self, data, connection):
@@ -346,7 +351,7 @@ class Claims(StorageCommandPlugin):
                                      "this server.")
 
     @Command("planet_access",
-             role=Registered,
+             perm="claims.planet_access",
              doc="Allows or disallows players to beam down to the planet.")
     def _planet_access(self, data, connection):
         location = str(connection.player.location)
@@ -438,7 +443,7 @@ class Claims(StorageCommandPlugin):
                                          .format(target.alias, allow))
                     else:
                         send_message(connection, "{} is not on the {} list "
-                                                "for this planet."
+                                                 "for this planet."
                                      .format(target.alias, allow))
                 else:
                     send_message(connection, "Argument not recognized. "

--- a/plugins/claims.py
+++ b/plugins/claims.py
@@ -182,7 +182,6 @@ class Claims(StorageCommandPlugin):
                                      "successfully.".format(location))
 
     @Command("add_builder",
-             role=Registered,
              priority=1,
              perm="claims.manage_claims",
              doc="Add someone to the protected list of your planet.")
@@ -215,7 +214,6 @@ class Claims(StorageCommandPlugin):
                          .format(" ".join(data)))
 
     @Command("del_builder",
-             role=Registered,
              priority=1,
              perm="claims.manage_claims",
              doc="Remove someone from the protected list of your planet.")
@@ -243,7 +241,6 @@ class Claims(StorageCommandPlugin):
                          .format(" ".join(data)))
 
     @Command("list_builders",
-             role=Registered,
              priority=1,
              perm="claims.manage_claims",
              doc="List all of the people allowed to build on this planet.")
@@ -322,7 +319,6 @@ class Claims(StorageCommandPlugin):
             send_message(connection, "You haven't claimed any worlds.")
 
     @Command("set_greeting",
-             role=Registered,
              priority=1,
              perm="claims.manage_claims",
              doc="Sets a custom greeting message for the planet, or clears "

--- a/plugins/claims.py
+++ b/plugins/claims.py
@@ -40,8 +40,7 @@ class Claims(StorageCommandPlugin):
 
     def is_owner(self, connection, location):
         uuid = connection.player.uuid
-        if self.plugins.player_manager.perm_check(connection.player,
-                                                  "planet_protect.bypass"):
+        if connection.player.perm_check("planet_protect.bypass"):
             return True
         if uuid not in self.storage["owners"]:
             return False
@@ -97,8 +96,7 @@ class Claims(StorageCommandPlugin):
         yield from asyncio.sleep(.5)
         if str(connection.player.location) in self.storage["access"]:
             access = self.storage["access"][str(connection.player.location)]
-            if self.plugins.player_manager.perm_check(connection.player,
-                                                      "planet_protect.bypass"):
+            if connection.player.perm_check("planet_protect.bypass"):
                 return
             elif connection.player.uuid in access["list"] and not \
                     access["whitelist"]:
@@ -275,7 +273,7 @@ class Claims(StorageCommandPlugin):
             elif location.locationtype() is "ShipWorld":
                 send_message(connection, "Can't transfer ownership of your "
                                          "ship!")
-            elif 'Registered' not in target.roles:
+            elif target.perm_check("claims.claim"):
                 send_message(connection, "Target is not high enough rank to "
                                          "own a planet!")
             else:

--- a/plugins/command_dispatcher.py
+++ b/plugins/command_dispatcher.py
@@ -159,6 +159,6 @@ class CommandDispatcher(BasePlugin):
             send_message(connection, str(e))
         except SystemExit as e:
             raise SystemExit
-        except:
+        except Exception:
             self.logger.exception("Unknown exception encountered. Ignoring.",
                                   exc_info=True)

--- a/plugins/discord_bot.py
+++ b/plugins/discord_bot.py
@@ -39,18 +39,6 @@ class MockPlayer:
     revoked_perms = set()
     permissions = set()
 
-    def check_role(self, role):
-        """
-        Mimics the 'check_role' function of the real Player object.
-
-        This is mainly a hack to make sure commands give in IRC don't give
-        more information than they should (eg - only see what a guest sees).
-
-        :param role: Role to be checked. We're ignoring this.
-        :return: Boolean: False. We're a restricted bot.
-        """
-        return False
-
 
 class MockConnection:
     """

--- a/plugins/discord_bot.py
+++ b/plugins/discord_bot.py
@@ -33,11 +33,11 @@ class MockPlayer:
     real Player object that don't map correctly, and would cause all sorts
     of headaches.
     """
-    owner = {x.__name__ for x in Owner.roles}
-    guest = {x.__name__ for x in DiscordBot.roles}
-    roles = set()
     name = "DiscordBot"
     logged_in = True
+    granted_perms = set()
+    revoked_perms = set()
+    permissions = set()
 
     def check_role(self, role):
         """
@@ -236,11 +236,11 @@ class DiscordPlugin(BasePlugin, discord.Client):
         split = data.split()
         command = split[0]
         to_parse = split[1:]
-        self.mock_connection.player.roles = \
-            self.mock_connection.player.guest
+        self.mock_connection.player.permissions = \
+            self.plugins.player_manager.ranks["Guest"]["permissions"]
         if command in self.dispatcher.commands:
             # Only handle commands that work from Discord
-            if command in ('who', 'help'):
+            if command in ('who', 'help', 'uptime'):
                 if self.irc_bot_exists:
                     asyncio.ensure_future(self.irc.bot_write(
                         "[DC] <{}> .{}".format(user, " ".join(split))

--- a/plugins/emotes.py
+++ b/plugins/emotes.py
@@ -56,7 +56,7 @@ class Emotes(StorageMixin, SimpleCommandPlugin):
         self.irc_active = link_plugin_if_available(self, "irc_bot")
         self.discord_active = link_plugin_if_available(self, "discord_bot")
         self.chat_enhancements = link_plugin_if_available(self,
-                                                      "chat_enhancements")
+                                                          "chat_enhancements")
 
     # Helper functions - Used by commands
 
@@ -71,6 +71,7 @@ class Emotes(StorageMixin, SimpleCommandPlugin):
     # Commands - In-game actions that can be performed
 
     @Command("me",
+             perm="emotes.emote",
              doc="Perform emote actions.")
     def _emote(self, data, connection):
         """
@@ -105,7 +106,7 @@ class Emotes(StorageMixin, SimpleCommandPlugin):
                 if self.discord_active:
                     asyncio.ensure_future(self.plugins["discord_bot"]
                         .bot_write(" -*- {} {}".format(
-                        connection.player.alias, emote)))
+                                    connection.player.alias, emote)))
                 message = "^orange;{} {}".format(connection.player.alias,
                                                  emote)
                 try:
@@ -118,6 +119,7 @@ class Emotes(StorageMixin, SimpleCommandPlugin):
                     broadcast(connection, message)
 
     @Command("mel",
+             perm="emotes.emote",
              doc="Perform emote actions in local chat.")
     def _emote_local(self, data, connection):
         """

--- a/plugins/general_commands.py
+++ b/plugins/general_commands.py
@@ -51,7 +51,14 @@ class GeneralCommands(SimpleCommandPlugin):
     default_config = {"maintenance_message": "This server is currently in "
                                              "maintenance mode and is not "
                                              "accepting new connections."}
+
+    def __init__(self):
+        super.__init__(self)
+        self.maintenance = False
+        self.rejection_message = ""
+        self.start_time = None
     # Helper functions - Used by commands
+
     def activate(self):
         super().activate()
         self.maintenance = False
@@ -103,6 +110,7 @@ class GeneralCommands(SimpleCommandPlugin):
     # Commands - In-game actions that can be performed
 
     @Command("who",
+             perm="general_commands.who",
              doc="Lists players who are currently logged in.")
     def _who(self, data, connection):
         """
@@ -126,7 +134,7 @@ class GeneralCommands(SimpleCommandPlugin):
                                                      ", ".join(ret_list)))
 
     @Command("whois",
-             role=Whois,
+             perm="general_commands.whois",
              doc="Returns client data about the specified user.",
              syntax="(username)")
     def _whois(self, data, connection):
@@ -148,7 +156,7 @@ class GeneralCommands(SimpleCommandPlugin):
             send_message(connection, "Player not found!")
 
     @Command("give", "item", "give_item",
-             role=GiveItem,
+             perm="general_commands.give_item",
              doc="Gives an item to a player. "
                  "If player name is omitted, give item(s) to self.",
              syntax=("[player=self]", "(item name)", "[count=1]"))
@@ -206,7 +214,7 @@ class GeneralCommands(SimpleCommandPlugin):
             connection.player.alias, item, count))
 
     @Command("nick",
-             role=Nick,
+             perm="general_commands.nick",
              doc="Changes your nickname to another one.",
              syntax="(username)")
     def _nick(self, data, connection):
@@ -239,7 +247,7 @@ class GeneralCommands(SimpleCommandPlugin):
                 old_alias, clean_alias))
 
     @Command("serverwhoami",
-             role=Whoami,
+             perm="general_commands.whoami",
              doc="Displays your current nickname for chat.")
     def _whoami(self, data, connection):
         """
@@ -253,7 +261,7 @@ class GeneralCommands(SimpleCommandPlugin):
                      self.generate_whois(connection.player))
 
     @Command("here",
-             role=Whoami,
+             perm="general_commands.here",
              doc="Displays all players on the same planet as you.")
     def _here(self, data, connection):
         """
@@ -278,7 +286,7 @@ class GeneralCommands(SimpleCommandPlugin):
                                                         ", ".join(ret_list)))
 
     @Command("uptime",
-             role=Whoami,
+             perm="general_commands.uptime",
              doc="Displays the time since the server started.")
     def _uptime(self, data, connection):
         """
@@ -291,7 +299,7 @@ class GeneralCommands(SimpleCommandPlugin):
         yield from send_message(connection, "Uptime: {}".format(current_time))
 
     @Command("shutdown",
-             role=Shutdown,
+             perm="general_commands.shutdown",
              doc="Shutdown the server after N seconds (default 5).",
              syntax="[time]")
     def _shutdown(self, data, connection):
@@ -319,7 +327,7 @@ class GeneralCommands(SimpleCommandPlugin):
         sys.exit()
 
     @Command("maintenance_mode",
-             role=SuperAdmin,
+             perm="general_commands.maintenance_mode",
              doc="Toggle maintenance mode on the server. While in "
                  "maintenance mode, the server will reject all new "
                  "connection.")

--- a/plugins/general_commands.py
+++ b/plugins/general_commands.py
@@ -53,7 +53,7 @@ class GeneralCommands(SimpleCommandPlugin):
                                              "accepting new connections."}
 
     def __init__(self):
-        super.__init__(self)
+        super().__init__()
         self.maintenance = False
         self.rejection_message = ""
         self.start_time = None
@@ -81,7 +81,7 @@ class GeneralCommands(SimpleCommandPlugin):
             last_seen = target.last_seen
         return ("Name: {} {}\n"
                 "Raw Name: {}\n"
-                "Roles: ^yellow;{}^green;\n"
+                "Ranks: ^yellow;{}^green;\n"
                 "UUID: ^yellow;{}^green;\n"
                 "IP address: ^cyan;{}^green;\n"
                 "Team ID: ^cyan;{}^green;\n"
@@ -89,7 +89,7 @@ class GeneralCommands(SimpleCommandPlugin):
                 "Last seen: ^yellow;{}^green;".format(
                     target.alias, logged_in,
                     target.name,
-                    ", ".join(target.roles),
+                    ", ".join(target.ranks),
                     target.uuid,
                     target.ip,
                     target.team_id,

--- a/plugins/general_commands.py
+++ b/plugins/general_commands.py
@@ -97,7 +97,8 @@ class GeneralCommands(SimpleCommandPlugin):
                     last_seen))
 
     def on_connect_success(self, data, connection):
-        if self.maintenance and "SuperAdmin" not in connection.player.roles:
+        if self.maintenance and not connection.player.perm_check(
+                "general_commands.maintenance_bypass"):
             fail = data_parser.ConnectFailure.build(dict(
                 reason=self.rejection_message))
             pkt = pparser.build_packet(packets.packets['connect_failure'],
@@ -123,7 +124,7 @@ class GeneralCommands(SimpleCommandPlugin):
         ret_list = []
         for player in self.plugins['player_manager'].players_online:
             target = self.plugins['player_manager'].get_player_by_uuid(player)
-            if connection.player.check_role(Moderator):
+            if connection.player.perm_check("general_commands.who_clientids"):
                 ret_list.append(
                     "[^red;{}^reset;] {}".format(target.client_id,
                                                  target.alias))
@@ -225,7 +226,8 @@ class GeneralCommands(SimpleCommandPlugin):
         :param connection: The connection from which the packet came.
         :return: Null.
         """
-        if len(data) > 1 and connection.player.check_role(Admin):
+        if len(data) > 1 and connection.player.perm_check(
+                "general_commands.nick_others"):
             target = self.plugins.player_manager.find_player(data[0])
             alias = " ".join(data[1:])
         else:
@@ -275,7 +277,8 @@ class GeneralCommands(SimpleCommandPlugin):
         location = str(connection.player.location)
         for p in self.factory.connections:
             if str(p.player.location) == location:
-                if connection.player.check_role(Moderator):
+                if connection.player.perm_check(
+                        "general_commands.who_clientids"):
                     ret_list.append(
                         "[^red;{}^reset;] {}".format(p.player.client_id,
                                                      p.player.alias))

--- a/plugins/help.py
+++ b/plugins/help.py
@@ -30,6 +30,7 @@ class HelpPlugin(SimpleCommandPlugin):
     # Commands - In-game actions that can be performed
 
     @Command("help",
+             perm="help.help",
              doc="Help command.")
     def _help(self, data, connection):
         """

--- a/plugins/help.py
+++ b/plugins/help.py
@@ -47,8 +47,7 @@ class HelpPlugin(SimpleCommandPlugin):
         if not data:
             commands = []
             for c, f in self.commands.items():
-                if self.plugins.player_manager.perm_check(connection.player,
-                                                          f.perm):
+                if connection.player.perm_check(f.perm):
                     commands.append(c)
             send_message(connection,
                          "Available commands: {}".format(" ".join(

--- a/plugins/help.py
+++ b/plugins/help.py
@@ -47,9 +47,9 @@ class HelpPlugin(SimpleCommandPlugin):
         if not data:
             commands = []
             for c, f in self.commands.items():
-                if f.roles - connection.player.roles:
-                    continue
-                commands.append(c)
+                if self.plugins.player_manager.perm_check(connection.player,
+                                                          f.perm):
+                    commands.append(c)
             send_message(connection,
                          "Available commands: {}".format(" ".join(
                              [command for command in sorted(commands)])))

--- a/plugins/irc_bot.py
+++ b/plugins/irc_bot.py
@@ -300,7 +300,7 @@ class IRCPlugin(BasePlugin):
                     self.logger.info(" -*- " + nick + " " + message)
                 if self.discord_active:
                     asyncio.ensure_future(self.discord.bot_write(
-                        "-*- {} {}".format(nick,message)))
+                        "-*- {} {}".format(nick, message)))
                 yield from self.factory.broadcast(
                     "< ^orange;IRC^reset; > ^green;-*- {} {}".format(nick,
                                                                      message),
@@ -312,7 +312,7 @@ class IRCPlugin(BasePlugin):
                 asyncio.ensure_future(self.discord.bot_write(
                     "[IRC] **<{}>** {}".format(nick, message)))
             yield from self.factory.broadcast("[^orange;IRC^reset;] <{}> "
-                                          "{}".format(nick, message),
+                                              "{}".format(nick, message),
                                               mode=ChatReceiveMode.BROADCAST)
 
     @asyncio.coroutine

--- a/plugins/irc_bot.py
+++ b/plugins/irc_bot.py
@@ -34,11 +34,11 @@ class MockPlayer:
     real Player object that don't map correctly, and would cause all sorts
     of headaches.
     """
-    owner = {x.__name__ for x in Owner.roles}
-    guest = {x.__name__ for x in IRCBot.roles}
-    roles = set()
     name = "IRCBot"
     logged_in = True
+    granted_perms = set()
+    revoked_perms = set()
+    permissions = set()
 
     def check_role(self, role):
         """
@@ -367,12 +367,14 @@ class IRCPlugin(BasePlugin):
         command = split[0]
         to_parse = split[1:]
         user = mask.split("!")[0]
-        self.connection.player.roles = self.connection.player.guest
+        self.connection.player.permissions = \
+            self.plugins.player_manager.ranks["Guest"]["permissions"]
         if user in self.ops:
-            self.connection.player.roles = self.connection.player.owner
+            self.connection.player.roles = \
+                self.plugins.player_manager.ranks["Admin"]["permissions"]
         if command in self.dispatcher.commands:
             # Only handle commands that work from IRC
-            if command in ('who', 'help'):
+            if command in ('who', 'help', 'uptime'):
                 if self.discord_active:
                     asyncio.ensure_future(self.discord.bot_write(
                         "[IRC] <**{}**> .{}".format(user, " ".join(split))))

--- a/plugins/irc_bot.py
+++ b/plugins/irc_bot.py
@@ -40,18 +40,6 @@ class MockPlayer:
     revoked_perms = set()
     permissions = set()
 
-    def check_role(self, role):
-        """
-        Mimics the 'check_role' function of the real Player object.
-
-        This is mainly a hack to make sure commands give in IRC don't give
-        more information than they should (eg - only see what a guest sees).
-
-        :param role: Role to be checked. We're ignoring this.
-        :return: Boolean: False. We're a restricted bot.
-        """
-        return False
-
 
 class MockConnection:
     """
@@ -370,7 +358,7 @@ class IRCPlugin(BasePlugin):
         self.connection.player.permissions = \
             self.plugins.player_manager.ranks["Guest"]["permissions"]
         if user in self.ops:
-            self.connection.player.roles = \
+            self.connection.player.permissions = \
                 self.plugins.player_manager.ranks["Admin"]["permissions"]
         if command in self.dispatcher.commands:
             # Only handle commands that work from IRC

--- a/plugins/motd.py
+++ b/plugins/motd.py
@@ -71,7 +71,7 @@ class MOTD(SimpleCommandPlugin):
     # Commands - In-game actions that can be performed
 
     @Command("set_motd",
-             role=SetMOTD,
+             perm="motd.set_motd",
              doc="Sets the 'Message of the Day' text.",
              syntax="(message text)")
     def _set_motd(self, data, connection):
@@ -90,6 +90,7 @@ class MOTD(SimpleCommandPlugin):
             return True
 
     @Command("motd",
+             perm="motd.motd",
              doc="Displays the 'Message of the Day' text.")
     def _motd(self, data, connection):
         """

--- a/plugins/planet_announcer.py
+++ b/plugins/planet_announcer.py
@@ -10,7 +10,6 @@ Reimplemented for StarryPy3k by medeor413.
 import asyncio
 
 from base_plugin import StorageCommandPlugin
-from plugins.player_manager import Admin
 from utilities import send_message, Command
 
 
@@ -49,7 +48,7 @@ class PlanetAnnouncer(StorageCommandPlugin):
             send_message(connection, self.storage["greetings"][location])
 
     @Command("set_greeting",
-             role=Admin,
+             role="planet_announcer.set_greeting",
              doc="Sets the greeting message to be displayed when a player "
                  "enters this planet, or clears it if unspecified.")
     def _set_greeting(self, data, connection):

--- a/plugins/planet_announcer.py
+++ b/plugins/planet_announcer.py
@@ -48,7 +48,7 @@ class PlanetAnnouncer(StorageCommandPlugin):
             send_message(connection, self.storage["greetings"][location])
 
     @Command("set_greeting",
-             role="planet_announcer.set_greeting",
+             perm="planet_announcer.set_greeting",
              doc="Sets the greeting message to be displayed when a player "
                  "enters this planet, or clears it if unspecified.")
     def _set_greeting(self, data, connection):

--- a/plugins/planet_protect.py
+++ b/plugins/planet_protect.py
@@ -95,8 +95,7 @@ class PlanetProtect(StorageCommandPlugin):
         protection = self.get_protection(connection.player.location)
         if not protection.protected:
             return True
-        if self.plugins.player_manager.perm_check(connection.player,
-                                                  "planet_protect.bypass"):
+        if connection.player.perm_check("planet_protect.bypass"):
             return True
         elif protection.check_builder(connection.player):
             return True
@@ -133,8 +132,7 @@ class PlanetProtect(StorageCommandPlugin):
         protection = self.get_protection(connection.player.location)
         if not protection.protected:
             return True
-        elif self.plugins.player_manager.perm_check(connection.player,
-                                                    "planet_protect.bypass"):
+        elif connection.player.perm_check("planet_protect.bypass"):
             return True
         elif protection.check_builder(connection.player):
             return True
@@ -174,8 +172,7 @@ class PlanetProtect(StorageCommandPlugin):
         protection = self.get_protection(connection.player.location)
         if not protection.protected:
             return True
-        elif self.plugins.player_manager.perm_check(connection.player,
-                                                    "planet_protect.bypass"):
+        elif connection.player.perm_check("planet_protect.bypass"):
             return True
         elif protection.check_builder(connection.player):
             return True

--- a/plugins/planet_protect.py
+++ b/plugins/planet_protect.py
@@ -76,7 +76,6 @@ class PlanetProtect(StorageCommandPlugin):
                 protection.allowed_builders = {x for x in convert.values()}
             self.storage["converted"] = True
 
-
     # Packet hooks - look for these packets and act on them
 
     def on_spawn_entity(self, data, connection):
@@ -96,7 +95,8 @@ class PlanetProtect(StorageCommandPlugin):
         protection = self.get_protection(connection.player.location)
         if not protection.protected:
             return True
-        if connection.player.check_role(Admin):
+        if self.plugins.player_manager.perm_check(connection.player,
+                                                  "planet_protect.bypass"):
             return True
         elif protection.check_builder(connection.player):
             return True
@@ -133,7 +133,8 @@ class PlanetProtect(StorageCommandPlugin):
         protection = self.get_protection(connection.player.location)
         if not protection.protected:
             return True
-        if connection.player.check_role(Admin):
+        elif self.plugins.player_manager.perm_check(connection.player,
+                                                    "planet_protect.bypass"):
             return True
         elif protection.check_builder(connection.player):
             return True
@@ -173,7 +174,8 @@ class PlanetProtect(StorageCommandPlugin):
         protection = self.get_protection(connection.player.location)
         if not protection.protected:
             return True
-        if connection.player.check_role(Admin):
+        elif self.plugins.player_manager.perm_check(connection.player,
+                                                    "planet_protect.bypass"):
             return True
         elif protection.check_builder(connection.player):
             return True
@@ -269,7 +271,7 @@ class PlanetProtect(StorageCommandPlugin):
     # Commands - In-game actions that can be performed
 
     @Command("protect",
-             role=Protect,
+             perm="planet_protect.protect",
              doc="Protects a planet",
              syntax="")
     def _protect(self, data, connection):
@@ -286,7 +288,7 @@ class PlanetProtect(StorageCommandPlugin):
         send_message(connection, "Protected location: {}".format(location))
 
     @Command("unprotect",
-             role=Protect,
+             perm="planet_protect.protect",
              doc="Removes protection from a planet",
              syntax="")
     def _unprotect(self, data, connection):
@@ -303,7 +305,7 @@ class PlanetProtect(StorageCommandPlugin):
         send_message(connection, "Unprotected location ()".format(location))
 
     @Command("add_builder",
-             role=Protect,
+             perm="planet_protect.manage_protection",
              doc="Adds a player to the current location's build list.",
              syntax="[\"](player name)[\"]")
     def _add_builder(self, data, connection):
@@ -336,7 +338,7 @@ class PlanetProtect(StorageCommandPlugin):
                              " ".join(data)))
 
     @Command("del_builder",
-             role=Protect,
+             perm="planet_protect.manage_protection",
              doc="Deletes a player from the current location's build list",
              syntax="[\"](player name)[\"]")
     def _del_builder(self, data, connection):
@@ -359,7 +361,7 @@ class PlanetProtect(StorageCommandPlugin):
                              " ".join(data)))
 
     @Command("list_builders",
-             role=Protect,
+             perm="planet_protect.manage_protection",
              doc="Lists all players granted build permissions "
                  "at current location",
              syntax="")
@@ -378,9 +380,9 @@ class PlanetProtect(StorageCommandPlugin):
             protection = self.get_protection(connection.player.location)
             uuids = protection.get_builders()
             aliases = []
-            for id in uuids:
+            for uid in uuids:
                 aliases.append(self.plugins['player_manager']
-                               .get_player_by_uuid(id).alias)
+                               .get_player_by_uuid(uid).alias)
             aliases = ", ".join(aliases)
             send_message(connection,
                          "Players allowed to build at location '{}': {}"

--- a/plugins/player_manager.py
+++ b/plugins/player_manager.py
@@ -1151,13 +1151,34 @@ class PlayerManager(SimpleCommandPlugin):
             send_message(connection, str(e))
 
     @Command("user",
+             perm="player_manager.user",
              doc="Manages user permissions; see /user help for details.")
     def _user(self, data, connection):
         if not data:
             yield from send_message(connection, "No arguments provided. See "
                                                 "/user help for usage info.")
         elif data[0] == "help":
-            yield from send_message(connection, "placeholder")
+            send_message(connection, "Syntax:")
+            send_message(connection, "/user addperm (user) (permission)")
+            send_message(connection, "Adds a permission to a player. Fails if "
+                                     "the user doesn't have the permission.")
+            send_message(connection, "/user rmperm (player) (permission)")
+            send_message(connection, "Removes a permission from a player. "
+                                     "Fails if the user doesn't have the"
+                                     " permission, or if the target's priority"
+                                     " is higher than the user's.")
+            send_message(connection, "/user addrank (player) (rank)")
+            send_message(connection, "Adds a rank to a player. Fails if the "
+                                     "rank to be added is equal to or "
+                                     "greater than the user's highest rank.")
+            send_message(connection, "/user rmrank (player) (rank)")
+            send_message(connection, "Removes a rank from a player. Fails if "
+                                     "the target outranks or is equal in rank"
+                                     " to the user.")
+            send_message(connection, "/user listperms (player)")
+            send_message(connection, "Lists the permissions a player has.")
+            send_message(connection, "/user listranks (player)")
+            send_message(connection, "Lists the ranks a player has.")
         elif data[0] == "addperm":
             target = self.find_player(data[1])
             if target:

--- a/plugins/player_manager.py
+++ b/plugins/player_manager.py
@@ -147,6 +147,17 @@ class Player:
             self.priority = ranks[highest_rank]['priority']
             self.chat_prefix = ranks[highest_rank]['prefix']
 
+    def perm_check(self, perm):
+        if not perm:
+            return True
+        elif "special.allperms" in self.permissions:
+            return True
+        elif perm in self.revoked_perms:
+            return False
+        elif perm in self.permissions:
+            return True
+        else:
+            return False
 
 class Ship:
     """
@@ -588,18 +599,6 @@ class PlayerManager(SimpleCommandPlugin):
             final[rank] = config
 
         return final
-
-    def perm_check(self, player, perm):
-        if not perm:
-            return True
-        elif "special.allperms" in player.permissions:
-            return True
-        elif perm in player.revoked_perms:
-            return False
-        elif perm in player.permissions:
-            return True
-        else:
-            return False
 
     def ban_by_ip(self, ip, reason, connection):
         """
@@ -1090,7 +1089,7 @@ class PlayerManager(SimpleCommandPlugin):
                 if not data[2]:
                     yield from send_message(connection, "No permission "
                                                         "specified.")
-                elif not self.perm_check(connection.player, data[2]):
+                elif not connection.player.perm_check(data[2]):
                     yield from send_message(connection, "You don't have "
                                             "permission to do that!")
                 elif data[2] in target.permissions:
@@ -1113,7 +1112,7 @@ class PlayerManager(SimpleCommandPlugin):
                 if not data[2]:
                     yield from send_message(connection, "No permission "
                                                         "specified.")
-                elif not self.perm_check(connection.player, data[2]):
+                elif not connection.player.perm_check(data[2]):
                     yield from send_message(connection, "You don't have "
                                             "permission to do that!")
                 elif target.priority >= connection.player.priority:

--- a/plugins/player_manager.py
+++ b/plugins/player_manager.py
@@ -590,7 +590,9 @@ class PlayerManager(SimpleCommandPlugin):
         return final
 
     def perm_check(self, player, perm):
-        if "special.allperms" in player.permissions:
+        if not perm:
+            return True
+        elif "special.allperms" in player.permissions:
             return True
         elif perm in player.revoked_perms:
             return False

--- a/plugins/poi.py
+++ b/plugins/poi.py
@@ -68,6 +68,7 @@ class POI(StorageCommandPlugin):
     # Commands - In-game actions that can be performed
 
     @Command("poi",
+             perm="poi.poi",
              doc="Moves a player's ship to the specified Point of Interest, "
                  "or prints the POIs if no argument given.",
              syntax="[\"][POI name][\"]")
@@ -103,7 +104,7 @@ class POI(StorageCommandPlugin):
             pass
 
     @Command("set_poi",
-             role=POIControl,
+             perm="poi.set_poi",
              doc="Set the planet you're on as a POI.",
              syntax="[\"](POI name)[\"]")
     def _set_poi(self, data, connection):
@@ -134,7 +135,7 @@ class POI(StorageCommandPlugin):
                      "POI {} added to list!".format(poi_name))
 
     @Command("del_poi",
-             role=POIControl,
+             perm="poi.set_poi",
              doc="Remove the specified POI from the POI list.",
              syntax="[\"](POI name)[\"]")
     def _del_poi(self, data, connection):

--- a/plugins/privileged_chatter.py
+++ b/plugins/privileged_chatter.py
@@ -35,6 +35,7 @@ class PrivilegedChatter(SimpleCommandPlugin):
         super().__init__()
         self.modchat_color = None
         self.report_prefix = None
+        self.broadcast_prefix = None
 
     def activate(self):
         super().activate()
@@ -48,7 +49,7 @@ class PrivilegedChatter(SimpleCommandPlugin):
     # Commands - In-game actions that can be performed
 
     @Command("modchat", "m",
-             role=ModeratorChat,
+             perm="privileged_chatter.modchat",
              doc="Send a message that can only be seen by other moderators.",
              syntax="(message)")
     def _moderatorchat(self, data, connection):
@@ -76,6 +77,7 @@ class PrivilegedChatter(SimpleCommandPlugin):
                                             channel=channel)
 
     @Command("report",
+             perm="privileged_chatter.report",
              doc="Privately make a report to all online moderators.",
              syntax="(message)")
     def _report(self, data, connection):
@@ -103,7 +105,7 @@ class PrivilegedChatter(SimpleCommandPlugin):
                                             channel=channel)
 
     @Command("broadcast",
-             role=Broadcast,
+             perm="privileged_chatter.broadcast",
              doc="Sends a message to everyone on the server.",
              syntax="(message)")
     def _broadcast(self, data, connection):

--- a/plugins/privileged_chatter.py
+++ b/plugins/privileged_chatter.py
@@ -67,7 +67,7 @@ class PrivilegedChatter(SimpleCommandPlugin):
             send_mode = ChatReceiveMode.BROADCAST
             channel = ""
             for p in self.factory.connections:
-                if "ModeratorChat" in p.player.roles:
+                if p.player.perm_check("privileged_chatter.modchat"):
                     yield from send_message(p,
                                             "{}{}^reset;".format(
                                                 self.modchat_color, message),
@@ -95,7 +95,8 @@ class PrivilegedChatter(SimpleCommandPlugin):
             send_mode = ChatReceiveMode.BROADCAST
             channel = ""
             for p in self.factory.connections:
-                if "ModeratorChat" in p.player.roles or p == connection:
+                if p.player.perm_check("privileged_chatter.modchat") \
+                        or p == connection:
                     yield from send_message(p,
                                             "{}{}^reset;".format(
                                                 self.report_prefix, message),

--- a/plugins/spawn.py
+++ b/plugins/spawn.py
@@ -11,7 +11,6 @@ import asyncio
 import data_parser
 import pparser
 import packets
-from plugins.player_manager import SuperAdmin, Moderator
 from base_plugin import StorageCommandPlugin
 from utilities import Command, send_message
 
@@ -62,6 +61,7 @@ class Spawn(StorageCommandPlugin):
     # Commands - In-game actions that can be performed
 
     @Command("spawn",
+             perm="spawn.spawn",
              doc="Moves a player's ship to the spawn planet.")
     def _spawn(self, data, connection):
         """
@@ -88,7 +88,7 @@ class Spawn(StorageCommandPlugin):
             pass
 
     @Command("set_spawn",
-             role=SuperAdmin,
+             perm="spawn.set_spawn",
              doc="Set the spawn planet.")
     def _set_spawn(self, data, connection):
         """
@@ -108,7 +108,7 @@ class Spawn(StorageCommandPlugin):
         send_message(connection, "Spawn planet set to {}.".format(str(planet)))
 
     @Command("show_spawn",
-             role=Moderator,
+             perm="spawn.show_spawn",
              doc="Print the current spawn location.")
     def _show_spawn(self, data, connection):
         """

--- a/plugins/warp_plugin.py
+++ b/plugins/warp_plugin.py
@@ -16,6 +16,7 @@ from data_parser import PlayerWarp
 from pparser import build_packet
 from utilities import Command, send_message
 
+
 class Warp(Moderator):
     pass
 
@@ -32,6 +33,10 @@ class WarpPlugin(SimpleCommandPlugin):
     """Plugin which provides commands related to warping."""
     name = "warp_plugin"
     depends = ["player_manager", "command_dispatcher"]
+
+    def __init__(self):
+        super().__init__()
+        self.find_player = None
 
     def activate(self):
         super().activate()
@@ -64,7 +69,7 @@ class WarpPlugin(SimpleCommandPlugin):
         yield from from_player.connection.client_raw_write(full)
 
     @Command("tp",
-             role=Warp,
+             perm="warp.tp_player",
              doc="Warps a player to another player.",
              syntax=("[from player=self]", "(to player)"))
     def warp(self, data, connection):
@@ -90,7 +95,7 @@ class WarpPlugin(SimpleCommandPlugin):
             send_message(connection, "Warped to {}.".format(to_player.alias))
 
     @Command("tps",
-             role=WarpShip,
+             perm="warp.tp_ship",
              doc="Warps a player to another player's ship.",
              syntax=("[from player=self]", "(to player"))
     def ship_warp(self, data, connection):
@@ -109,8 +114,8 @@ class WarpPlugin(SimpleCommandPlugin):
         yield from self.warp_player_to_ship(from_player, to_player)
         if from_player.alias != connection.player.alias:
             send_message(from_player.connection, "You've been warped to {}'s"
-                                                 " ship.".format(
-                to_player.alias))
+                                                 " ship."
+                         .format(to_player.alias))
             send_message(connection, "Warped {} to {}'s ship.".format(
                 from_player.alias, to_player.alias))
         else:

--- a/utilities.py
+++ b/utilities.py
@@ -373,9 +373,7 @@ class Command:
         def wrapped(s, data, connection):
             try:
                 if self.perm is not None:
-                    if self.perm not in connection.player.permissions and \
-                            "special.allperms" not in \
-                            connection.player.permissions:
+                    if not connection.player.perm_check(self.perm):
                         raise PermissionError
                 return f(s, data, connection)
             except PermissionError:

--- a/utilities.py
+++ b/utilities.py
@@ -354,15 +354,8 @@ class Command:
             syntax = ()
         if isinstance(syntax, str):
             syntax = (syntax,)
-        if roles is None:
-            roles = set()
-        elif not isinstance(roles, set):
-            roles = {x for x in roles}
-        if role is not None:
-            roles.add(role)
         if doc is None:
             doc = ""
-        self.roles = {role.__name__ for role in roles}
         self.perm = perm
         self.syntax = syntax
         self.human_syntax = " ".join(syntax)
@@ -379,9 +372,6 @@ class Command:
         """
         def wrapped(s, data, connection):
             try:
-                for role in self.roles:
-                    if role not in connection.player.roles:
-                        raise PermissionError
                 if self.perm is not None:
                     if self.perm not in connection.player.permissions and \
                             "special.allperms" not in \
@@ -395,7 +385,7 @@ class Command:
         wrapped._command = True
         wrapped._aliases = self.aliases
         wrapped.__doc__ = self.doc
-        wrapped.roles = self.roles
+        wrapped.perm = self.perm
         wrapped.syntax = self.human_syntax
         wrapped.priority = self.priority
         # f.roles = self.roles

--- a/utilities.py
+++ b/utilities.py
@@ -348,7 +348,7 @@ class Command:
     interface for all commands, including roles, documentation, usage syntax,
     and aliases.
     """
-    def __init__(self, *aliases, role=None, roles=None, doc=None,
+    def __init__(self, *aliases, role=None, roles=None, perm=None, doc=None,
                  syntax=None, priority=0):
         if syntax is None:
             syntax = ()
@@ -363,6 +363,7 @@ class Command:
         if doc is None:
             doc = ""
         self.roles = {role.__name__ for role in roles}
+        self.perm = perm
         self.syntax = syntax
         self.human_syntax = " ".join(syntax)
         self.doc = doc
@@ -380,6 +381,11 @@ class Command:
             try:
                 for role in self.roles:
                     if role not in connection.player.roles:
+                        raise PermissionError
+                if self.perm is not None:
+                    if self.perm not in connection.player.permissions and \
+                            "special.allperms" not in \
+                            connection.player.permissions:
                         raise PermissionError
                 return f(s, data, connection)
             except PermissionError:


### PR DESCRIPTION
The role system that StarryPy has apparently used since its creation is rather flawed. The primary issue is that all roles are defined in the code, making customizing ranks to suit your server cumbersome. Another major issue with the current system is that when new permissions are added, roles must be re-awarded to users. This pull request rewrites the role system into something resembling the permissions system of something like the various Bukkit plugins for Minecraft, or TShock for Terraria, with an arbitrary number of ranks defined by the server operator that permissions can easily be given to or taken from with a config file edit. The system also allows permissions to be granted on a per-user basis.