### PR TITLE
Entity message blocker, location and permission related bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # StarryPy3k
 
-##About
+## About
 StarryPy3k is the successor to StarryPy. StarryPy is a plugin-driven Starbound
 server wrapper that adds a great deal of functionality to Starbound. StarryPy3k
  is written using asyncio is Python 3.
@@ -138,11 +138,27 @@ and privileges.  You can find your UUID by watching the Starbound server log
 as you connect, by using the `list` RCON command, or by observing the names
 of your save files on the computer you use to play Starbound.
 
+Once you have finished editing `config.json`, copy the `permissions.json.default`
+ file to `permissions.json` and edit it to your liking. Example of 
+ permissions format is provided below:
+ ```
+"Role Name": {
+  "priority": 100000, // This determines the role heirarchy for administrative commands such as /kick, /ban, and /user
+  "prefix": "^#F7434C;", // This role's chat prefix, typically a color
+  "inherits": [ // Roles to inherit permissions from
+    "Another Role"
+  ],
+  "permissions": [ // An array of permissions; see permissions.json.default for all the permissions included
+    "special.allperms"
+  ]
+}
+```
+
 ### Starting the proxy
 Starting StarryPy is as simple as issueing the command `python3 ./server.py`
-once you have finised editing `config/config.json`.  To terminate the proxy,
-either press `^C` in an interactive terminal session, or send it a `TERM`
-signal.
+once you have finised editing `config/config.json` and `config/permissions
+.json`.  To terminate the proxy, either press `^C` in an interactive 
+terminal session, or send it a `TERM` signal.
 
 
 ## Contributing

--- a/config/permissions.json.default
+++ b/config/permissions.json.default
@@ -43,7 +43,8 @@
       "poi.set_poi",
       "privileged_chatter.broadcast",
       "warp.tp_player",
-      "warp.tp_ship"
+      "warp.tp_ship",
+      "emsg_blocker.bypass"
     ]
   },
   "Moderator": {

--- a/data_parser.py
+++ b/data_parser.py
@@ -324,7 +324,7 @@ class Byte(Struct):
 class Flag(Struct):
     @classmethod
     def _parse(cls, stream: BytesIO, ctx: OrderedDict):
-        return bool(stream.read(1))
+        return struct.unpack(">?", stream.read(1))[0]
 
     @classmethod
     def _build(cls, obj, ctx: OrderedDotDict):
@@ -772,8 +772,8 @@ class EntityInteract(Struct):
 
 class EntityMessage(Struct):
     """packet type: 51"""
-    target_unique = Byte
-    if target_unique == 1:
+    target_unique = Flag
+    if target_unique:
         unique_id = StarString
     else:
         target_id = SBInt32

--- a/data_parser.py
+++ b/data_parser.py
@@ -772,15 +772,32 @@ class EntityInteract(Struct):
 
 class EntityMessage(Struct):
     """packet type: 51"""
-    target_unique = Flag
-    if target_unique:
-        unique_id = StarString
-    else:
-        target_id = SBInt32
-    message_name = StarString
-    message_args = VariantVariant
-    message_uuid = UUID
-    unknown_2 = UBInt16 # Also appears to always be 0
+    @classmethod
+    def _parse(cls, stream, ctx=None):
+        res = {}
+        res['target_unique'] = Flag.parse(stream, ctx)
+        if res['target_unique']:
+            res['unique_id'] = StarString.parse(stream, ctx)
+        else:
+            res['target_id'] = SBInt32.parse(stream, ctx)
+        res['message_name'] = StarString.parse(stream, ctx)
+        res['message_args'] = VariantVariant.parse(stream, ctx)
+        res['message_uuid'] = UUID.parse(stream, ctx)
+        res['unknown'] = UBInt16.parse(stream, ctx) # Appears to always be 0
+        return res
+
+    def _build(cls, obj, ctx=None):
+        res = b''
+        res += Flag.build(obj['target_unique'])
+        if obj['target_unique']:
+            res += StarString.build(obj['unique_id'])
+        else:
+            res += SBInt32.build(obj['target_id'])
+        res += StarString.build(obj['message_name'])
+        res += VariantVariant.build(obj['message_args'])
+        res += UUID.build(obj['message_uuid'])
+        res += UBInt16.build(obj['unknown'])
+        return res
 
 
 class EntityMessageResponse(Struct):

--- a/data_parser.py
+++ b/data_parser.py
@@ -334,7 +334,7 @@ class Flag(Struct):
 class BDouble(Struct):
     @classmethod
     def _parse(cls, stream: BytesIO, ctx: OrderedDict):
-        return struct.unpack(">d", stream.read(8))
+        return struct.unpack(">d", stream.read(8))[0]
 
     @classmethod
     def _build(cls, obj, ctx: OrderedDotDict):
@@ -804,7 +804,6 @@ class EntityMessageResponse(Struct):
     success_level = Byte # 1 is a failure, 2 is a success
     response = Variant
     message_uuid = UUID
-
 
 class StepUpdate(Struct):
     """packet type: 54"""

--- a/data_parser.py
+++ b/data_parser.py
@@ -769,10 +769,11 @@ class EntityInteract(Struct):
     target_y = BFloat32
     request_id = UUID
 
+
 class EntityMessage(Struct):
     """packet type: 51"""
-    target_unique = Flag
-    if target_unique:
+    target_unique = Byte
+    if target_unique == 1:
         unique_id = StarString
     else:
         target_id = SBInt32
@@ -781,10 +782,12 @@ class EntityMessage(Struct):
     message_uuid = UUID
     unknown_2 = UBInt16 # Also appears to always be 0
 
+
 class EntityMessageResponse(Struct):
     success_level = Byte # 1 is a failure, 2 is a success
     response = Variant
     message_uuid = UUID
+
 
 class StepUpdate(Struct):
     """packet type: 54"""

--- a/plugins/discord_bot.py
+++ b/plugins/discord_bot.py
@@ -66,7 +66,8 @@ class DiscordPlugin(BasePlugin, discord.Client):
         "client_id": "-- client_id --",
         "channel": "-- channel id --",
         "strip_colors": True,
-        "log_discord": False
+        "log_discord": False,
+        "command_prefix": "!"
     }
 
     def __init__(self):
@@ -78,6 +79,7 @@ class DiscordPlugin(BasePlugin, discord.Client):
         self.client_id = None
         self.mock_connection = None
         self.prefix = None
+        self.command_prefix = None
         self.dispatcher = None
         self.color_strip = re.compile("\^(.*?);")
         self.sc = None
@@ -92,6 +94,8 @@ class DiscordPlugin(BasePlugin, discord.Client):
         if self.irc_bot_exists:
             self.irc = self.plugins['irc_bot']
         self.prefix = self.config.get_plugin_config("command_dispatcher")[
+            "command_prefix"]
+        self.command_prefix = self.config.get_plugin_config(self.name)[
             "command_prefix"]
         self.token = self.config.get_plugin_config(self.name)["token"]
         self.client_id = self.config.get_plugin_config(self.name)["client_id"]
@@ -189,7 +193,7 @@ class DiscordPlugin(BasePlugin, discord.Client):
         text = message.clean_content
         server = message.server
         if message.author.id != self.client_id:
-            if message.content[0] == ".":
+            if message.content[0] == self.command_prefix:
                 asyncio.ensure_future(self.handle_command(message.content[
                                                           1:], nick))
             else:

--- a/plugins/discord_bot.py
+++ b/plugins/discord_bot.py
@@ -35,9 +35,23 @@ class MockPlayer:
     """
     name = "DiscordBot"
     logged_in = True
-    granted_perms = set()
-    revoked_perms = set()
-    permissions = set()
+
+    def __init__(self):
+        self.granted_perms = set()
+        self.revoked_perms = set()
+        self.permissions = set()
+
+    def perm_check(self, perm):
+        if not perm:
+            return True
+        elif "special.allperms" in self.permissions:
+            return True
+        elif perm.lower() in self.revoked_perms:
+            return False
+        elif perm.lower() in self.permissions:
+            return True
+        else:
+            return False
 
 
 class MockConnection:

--- a/plugins/emsg_blocker.py
+++ b/plugins/emsg_blocker.py
@@ -1,0 +1,53 @@
+"""
+StarryPy Entity Message Blocker Plugin
+
+Filter out harmful or malicious entity messages from players.
+
+Original authors: medeor413
+"""
+
+from base_plugin import BasePlugin
+from utilities import Direction
+
+
+class ChatLogger(BasePlugin):
+    name = "emsg_blocker"
+
+    def __init__(self):
+        super().__init__()
+        self.blocked_messages = []
+
+    def activate(self):
+        super().activate()
+        self.blocked_messages = [
+            "applyStatusEffect",
+            "warp",
+            "playAltMusic",
+            "stopAltMusic",
+            "playCinematic"
+        ]
+
+    def on_entity_message(self, data, connection):
+        """
+        Catch when an entity message is sent and block it, depending on its
+        contents.
+
+        :param data: The packet containing the message.
+        :param connection: The connection from which the packet came.
+        :return: Boolean; True if the message is allowed, false if it's
+        blocked.
+        """
+        if data['direction'] == Direction.TO_CLIENT:
+            # The server probably isn't sending malicious messages
+            return True
+        else:
+            if data['parsed']['message_name'] in self.blocked_messages:
+                if not connection.player.perm_check("emsg_blocker.bypass"):
+                    self.logger.debug("Blocked message {} from player {}."
+                                      .format(data['parsed']['message_name'],
+                                              connection.player.alias))
+                    return False
+                else:
+                    return True
+            else:
+                return True

--- a/plugins/irc_bot.py
+++ b/plugins/irc_bot.py
@@ -36,10 +36,23 @@ class MockPlayer:
     """
     name = "IRCBot"
     logged_in = True
-    granted_perms = set()
-    revoked_perms = set()
-    permissions = set()
 
+    def __init__(self):
+        self.granted_perms = set()
+        self.revoked_perms = set()
+        self.permissions = set()
+
+    def perm_check(self, perm):
+        if not perm:
+            return True
+        elif "special.allperms" in self.permissions:
+            return True
+        elif perm.lower() in self.revoked_perms:
+            return False
+        elif perm.lower() in self.permissions:
+            return True
+        else:
+            return False
 
 class MockConnection:
     """

--- a/plugins/irc_bot.py
+++ b/plugins/irc_bot.py
@@ -105,7 +105,8 @@ class IRCPlugin(BasePlugin):
         "username": "starrypy3k_bot",
         "strip_colors": True,
         "log_irc": False,
-        "announce_join_leave": True
+        "announce_join_leave": True,
+        "command_prefix": "!"
     }
 
     def __init__(self):
@@ -115,6 +116,7 @@ class IRCPlugin(BasePlugin):
         self.username = None
         self.connection = None
         self.prefix = None
+        self.command_prefix = None
         self.dispatcher = None
         self.bot = None
         self.ops = None
@@ -128,6 +130,8 @@ class IRCPlugin(BasePlugin):
         super().activate()
         self.dispatcher = self.plugins.command_dispatcher
         self.prefix = self.config.get_plugin_config("command_dispatcher")[
+            "command_prefix"]
+        self.command_prefix = self.config.get_plugin_config(self.name)[
             "command_prefix"]
         self.server = self.config.get_plugin_config(self.name)["server"]
         self.channel = self.config.get_plugin_config(self.name)["channel"]
@@ -226,7 +230,7 @@ class IRCPlugin(BasePlugin):
         :param data: Message body.
         :return: None
         """
-        if data[0] == ".":
+        if data[0] == self.command_prefix:
             asyncio.ensure_future(self.handle_command(target, data[1:], mask))
         elif target.lower() == self.channel.lower():
             nick = mask.split("!")[0]

--- a/plugins/player_manager.py
+++ b/plugins/player_manager.py
@@ -153,9 +153,9 @@ class Player:
             return True
         elif "special.allperms" in self.permissions:
             return True
-        elif perm in self.revoked_perms:
+        elif perm.lower() in self.revoked_perms:
             return False
-        elif perm in self.permissions:
+        elif perm.lower() in self.permissions:
             return True
         else:
             return False
@@ -1071,7 +1071,7 @@ class PlayerManager(SimpleCommandPlugin):
         if not data:
             yield from send_message(connection, "No arguments provided. See "
                                                 "/user help for usage info.")
-        elif data[0] == "help":
+        elif data[0].lower() == "help":
             send_message(connection, "Syntax:")
             send_message(connection, "/user addperm (user) (permission)")
             send_message(connection, "Adds a permission to a player. Fails if "
@@ -1093,7 +1093,7 @@ class PlayerManager(SimpleCommandPlugin):
             send_message(connection, "Lists the permissions a player has.")
             send_message(connection, "/user listranks (player)")
             send_message(connection, "Lists the ranks a player has.")
-        elif data[0] == "addperm":
+        elif data[0].lower() == "addperm":
             target = self.find_player(data[1])
             if target:
                 if not data[2]:
@@ -1102,13 +1102,13 @@ class PlayerManager(SimpleCommandPlugin):
                 elif not connection.player.perm_check(data[2]):
                     yield from send_message(connection, "You don't have "
                                             "permission to do that!")
-                elif data[2] in target.permissions:
+                elif data[2].lower() in target.permissions:
                     yield from send_message(connection, "Player {} already "
                                                         "has permission {}."
                                             .format(target.alias, data[2]))
                 else:
-                    target.revoked_perms.discard(data[2])
-                    target.granted_perms.add(data[2])
+                    target.revoked_perms.discard(data[2].lower())
+                    target.granted_perms.add(data[2].lower())
                     target.update_ranks(self.ranks)
                     yield from send_message(connection, "Granted permission "
                                                         "{} to {}."
@@ -1116,7 +1116,7 @@ class PlayerManager(SimpleCommandPlugin):
             else:
                 yield from send_message(connection, "User {} not "
                                                     "found.".format(data[1]))
-        elif data[0] == "rmperm":
+        elif data[0].lower() == "rmperm":
             target = self.find_player(data[1])
             if target:
                 if not data[2]:
@@ -1128,13 +1128,13 @@ class PlayerManager(SimpleCommandPlugin):
                 elif target.priority >= connection.player.priority:
                     yield from send_message(connection, "You don't have "
                                             "permission to do that!")
-                elif data[2] not in target.permissions:
+                elif data[2].lower() not in target.permissions:
                     yield from send_message(connection, "Player {} does not "
                                                         "have permission {}."
                                             .format(target.alias, data[2]))
                 else:
-                    target.granted_perms.discard(data[2])
-                    target.revoked_perms.add(data[2])
+                    target.granted_perms.discard(data[2].lower())
+                    target.revoked_perms.add(data[2].lower())
                     target.update_ranks(self.ranks)
                     yield from send_message(connection, "Removed permission "
                                                         "{} from {}."
@@ -1142,7 +1142,7 @@ class PlayerManager(SimpleCommandPlugin):
             else:
                 yield from send_message(connection, "User {} not "
                                                     "found.".format(data[1]))
-        elif data[0] == "addrank":
+        elif data[0].lower() == "addrank":
             target = self.find_player(data[1])
             if target:
                 if not data[2]:
@@ -1169,7 +1169,7 @@ class PlayerManager(SimpleCommandPlugin):
             else:
                 yield from send_message(connection, "User {} not "
                                                     "found.".format(data[1]))
-        elif data[0] == "rmrank":
+        elif data[0].lower() == "rmrank":
             target = self.find_player(data[1])
             if target:
                 if not data[2]:
@@ -1196,7 +1196,7 @@ class PlayerManager(SimpleCommandPlugin):
             else:
                 yield from send_message(connection, "User {} not "
                                                     "found.".format(data[1]))
-        elif data[0] == "listperms":
+        elif data[0].lower() == "listperms":
             target = self.find_player(data[1])
             if target:
                 perms = ", ".join(target.permissions)
@@ -1206,7 +1206,7 @@ class PlayerManager(SimpleCommandPlugin):
             else:
                 yield from send_message(connection, "User {} not "
                                                     "found.".format(data[1]))
-        elif data[0] == "listranks":
+        elif data[0].lower() == "listranks":
             target = self.find_player(data[1])
             if target:
                 ranks = ", ".join(target.ranks)

--- a/plugins/player_manager.py
+++ b/plugins/player_manager.py
@@ -408,31 +408,37 @@ class PlayerManager(SimpleCommandPlugin):
         :return: Boolean: True. Don't stop the packet here.
         """
         if data["parsed"]["warp_success"]:
-            connection.player.last_location = connection.player.location
             warp_data = data["parsed"]["warp_action"]
             p = connection.player
             if warp_data["warp_type"] == WarpType.TO_ALIAS:
                 if warp_data["alias_id"] == WarpAliasType.ORBITED:
                     # down to planet, need coordinates from world_start
+                    p.last_location = p.location
                     pass
                 elif warp_data["alias_id"] == WarpAliasType.SHIP:
                     # back on own ship
+                    p.last_location = p.location
                     p.location = yield from self._add_or_get_ship(p.uuid)
                 elif warp_data["alias_id"] == WarpAliasType.RETURN:
                     p.location, p.last_location = p.last_location, p.location
             elif warp_data["warp_type"] == WarpType.TO_PLAYER:
                 target = self.get_player_by_uuid(warp_data["player_id"]
                     .decode("utf-8"))
+                p.last_location = p.location
                 p.location = target.location
             elif warp_data["warp_type"] == WarpType.TO_WORLD:
                 if warp_data["world_id"] == WarpWorldType.CELESTIAL_WORLD:
+                    p.last_location = p.location
                     pass
                 elif warp_data["world_id"] == WarpWorldType.PLAYER_WORLD:
+                    p.last_location = p.location
                     p.location = yield from self._add_or_get_ship(
                         warp_data["ship_id"])
                 elif warp_data["world_id"] == WarpWorldType.UNIQUE_WORLD:
+                    p.last_location = p.location
                     p.location = yield from self._add_or_get_instance(warp_data)
                 elif warp_data["world_id"] == WarpWorldType.MISSION_WORLD:
+                    p.last_location = p.location
                     pass
         return True
 

--- a/plugins/player_manager.py
+++ b/plugins/player_manager.py
@@ -406,30 +406,31 @@ class PlayerManager(SimpleCommandPlugin):
         :param connection:
         :return: Boolean: True. Don't stop the packet here.
         """
-        warp_data = data["parsed"]["warp_action"]
-        if warp_data["warp_type"] == WarpType.TO_ALIAS:
-            if warp_data["alias_id"] == WarpAliasType.ORBITED:
-                # down to planet, need coordinates from world_start
-                pass
-            elif warp_data["alias_id"] == WarpAliasType.SHIP:
-                # back on own ship
-                connection.player.location = yield from self._add_or_get_ship(
-                    connection.player.uuid)
-        elif warp_data["warp_type"] == WarpType.TO_PLAYER:
-            target = self.get_player_by_uuid(warp_data["player_id"].decode(
-                "utf-8"))
-            connection.player.location = target.location
-        elif warp_data["warp_type"] == WarpType.TO_WORLD:
-            if warp_data["world_id"] == WarpWorldType.CELESTIAL_WORLD:
-                pass
-            elif warp_data["world_id"] == WarpWorldType.PLAYER_WORLD:
-                connection.player.location = yield from self._add_or_get_ship(
-                    warp_data["ship_id"])
-            elif warp_data["world_id"] == WarpWorldType.UNIQUE_WORLD:
-                connection.player.location = yield from \
-                    self._add_or_get_instance(warp_data)
-            elif warp_data["world_id"] == WarpWorldType.MISSION_WORLD:
-                pass
+        if data["parsed"]["warp_success"]:
+            warp_data = data["parsed"]["warp_action"]
+            if warp_data["warp_type"] == WarpType.TO_ALIAS:
+                if warp_data["alias_id"] == WarpAliasType.ORBITED:
+                    # down to planet, need coordinates from world_start
+                    pass
+                elif warp_data["alias_id"] == WarpAliasType.SHIP:
+                    # back on own ship
+                    connection.player.location = yield from \
+                        self._add_or_get_ship(connection.player.uuid)
+            elif warp_data["warp_type"] == WarpType.TO_PLAYER:
+                target = self.get_player_by_uuid(warp_data["player_id"]
+                    .decode("utf-8"))
+                connection.player.location = target.location
+            elif warp_data["warp_type"] == WarpType.TO_WORLD:
+                if warp_data["world_id"] == WarpWorldType.CELESTIAL_WORLD:
+                    pass
+                elif warp_data["world_id"] == WarpWorldType.PLAYER_WORLD:
+                    connection.player.location = yield from \
+                        self._add_or_get_ship(warp_data["ship_id"])
+                elif warp_data["world_id"] == WarpWorldType.UNIQUE_WORLD:
+                    connection.player.location = yield from \
+                        self._add_or_get_instance(warp_data)
+                elif warp_data["world_id"] == WarpWorldType.MISSION_WORLD:
+                    pass
         return True
 
     # def on_client_context_update(self, data, connection):

--- a/pparser.py
+++ b/pparser.py
@@ -58,7 +58,7 @@ parse_map = {
     50: None,
     51: EntityMessage,
     52: EntityMessageResponse,
-    53: None,
+    53: DictVariant,
     54: StepUpdate
 }
 

--- a/utilities.py
+++ b/utilities.py
@@ -249,7 +249,8 @@ def extractor(*args):
     # It's not elegant, but it's the best way to do it as far as I can tell.
     # My regex-fu isn't strong though, so if someone can come up with a
     # better way, great.
-    x = re.split(r"(?:([^\"]\S*)|\"(.+?)\")\s*", " ".join(*args))
+    x = re.split(r"(?:([^\"]\S*)|\"(.+?)(?<!\\)\")\s*", " ".join(*args))
+    x = [word.replace("\\\"", "\"") if word is not None else None for word in x]
     return [x for x in filter(None, x)]
 
 


### PR DESCRIPTION
- Entity Message Blocker: A plugin to block potentially malicious entity messages. Can be bypassed with a permission for admin use.
- Player Manager: Don't change player location if warp fails
- Player Manager: Handle `Return` warp action
- Player Manager: Make permissions case-insensitive
- Command Dispatcher: Allow escaping quotes in commands
- Discord/IRC Bot: Allow changing of command prefix
- Discord/IRC Bot: Change default command prefix from `.` to `!`
- Discord/IRC Bot: Add perm_check to MockPlayer
- Add some documentation for permissions.json