### PR TITLE
change_owner bugfixes

### DIFF
--- a/plugins/claims.py
+++ b/plugins/claims.py
@@ -284,8 +284,23 @@ class Claims(StorageCommandPlugin):
                     send_message(connection, "The target player has reached "
                                              "the maximum number of claims!")
                     return
+
+                try:
+                    self.storage["owners"][uuid].remove(str(location))
+                # If the command executor's UUID cannot be removed, they
+                # probably have the planet_protect.bypass permission and are
+                # changing the owner of a planet they do not own.
+                # In that case, we need to run through the list of owners and
+                # remove whoever owns the target planet.
+                except:
+                    for u in self.storage["owners"]:
+                        if str(location) in self.storage["owners"][u]:
+                            self.storage["owners"][u].remove(str(location))
+                            # Currently, this will check all UUIDs in case a
+                            # bug caused multiple owners. Break if undesired.
+                            #break
                 self.storage["owners"][target.uuid].append(str(location))
-                self.storage["owners"][uuid].remove(str(location))
+
                 if len(self.storage["owners"][uuid]) == 0:
                     self.storage["owners"].pop(uuid)
                 self.planet_protect.add_protection(location, target)

--- a/plugins/claims.py
+++ b/plugins/claims.py
@@ -290,15 +290,22 @@ class Claims(StorageCommandPlugin):
                 # If the command executor's UUID cannot be removed, they
                 # probably have the planet_protect.bypass permission and are
                 # changing the owner of a planet they do not own.
-                # In that case, we need to run through the list of owners and
-                # remove whoever owns the target planet.
+                # In that case, we need to verify this and run through the list
+                # of owners and remove whoever owns the target planet.
                 except:
-                    for u in self.storage["owners"]:
-                        if str(location) in self.storage["owners"][u]:
-                            self.storage["owners"][u].remove(str(location))
-                            # Currently, this will check all UUIDs in case a
-                            # bug caused multiple owners. Break if undesired.
-                            #break
+                    # Better safe than sorry.
+                    if connection.player.perm_check("planet_protect.bypass"):
+                        for u in self.storage["owners"]:
+                            if str(location) in self.storage["owners"][u]:
+                                self.storage["owners"][u].remove(str(location))
+                                # Currently, this will check all UUIDs in case a
+                                # bug caused multiple owners. Break if undesired.
+                                #break
+                    else:
+                        send_message(connection, "Something went wrong. "
+                                                 "Cannot change ownership "
+                                                 "without reqired permissions!")
+                        return
                 self.storage["owners"][target.uuid].append(str(location))
 
                 if len(self.storage["owners"][uuid]) == 0:

--- a/plugins/claims.py
+++ b/plugins/claims.py
@@ -273,7 +273,7 @@ class Claims(StorageCommandPlugin):
             elif location.locationtype() is "ShipWorld":
                 send_message(connection, "Can't transfer ownership of your "
                                          "ship!")
-            elif target.perm_check("claims.claim"):
+            elif not target.perm_check("claims.claim"):
                 send_message(connection, "Target is not high enough rank to "
                                          "own a planet!")
             else:


### PR DESCRIPTION
This addresses two bugs in the change_owner command:
1. The permissions check needed to be inverted. The command could only be run on users who did *not* have the correct permission.
2. If a staff member with the planet_protect.bypass permission tried to change the owner of a planet they did not own, the command would add the new owner but fail to remove the original one. This would result in the planet having two owners.