### PR TITLE
Fix a bunch of AttributeErrors

### DIFF
--- a/plugins/chat_enhancements.py
+++ b/plugins/chat_enhancements.py
@@ -125,7 +125,8 @@ class ChatEnhancements(StorageCommandPlugin):
         msg = "[SS]: " + data["parsed"]["message"]
         for p in self.social_spies:
             if data["parsed"]["send_mode"] in [ChatSendMode.LOCAL,
-                                               ChatSendMode.PARTY]:
+                                               ChatSendMode.PARTY] and \
+                    p.logged_in:
                 yield from send_message(p.connection,
                                         msg,
                                         mode=ChatReceiveMode.BROADCAST,
@@ -181,10 +182,11 @@ class ChatEnhancements(StorageCommandPlugin):
             msg = "[SS]: " + " ".join(data)
             sender = self.decorate_line(connection)
             for p in self.social_spies:
-                yield from send_message(p.connection,
-                                        msg,
-                                        mode=ChatReceiveMode.BROADCAST,
-                                        name=sender)
+                if p.logged_in:
+                    yield from send_message(p.connection,
+                                            msg,
+                                            mode=ChatReceiveMode.BROADCAST,
+                                            name=sender)
             yield from self._send_to_server(data,
                                             ChatSendMode.LOCAL,
                                             connection)
@@ -238,10 +240,11 @@ class ChatEnhancements(StorageCommandPlugin):
             msg = "[SS]: " + " ".join(data)
             sender = self.decorate_line(connection)
             for p in self.social_spies:
-                yield from send_message(p.connection,
-                                        msg,
-                                        mode=ChatReceiveMode.BROADCAST,
-                                        name=sender)
+                if p.logged_in:
+                    yield from send_message(p.connection,
+                                            msg,
+                                            mode=ChatReceiveMode.BROADCAST,
+                                            name=sender)
             yield from self._send_to_server(data,
                                             ChatSendMode.PARTY,
                                             connection)
@@ -306,10 +309,11 @@ class ChatEnhancements(StorageCommandPlugin):
                                                   recipient.alias)
             ssmsg = "[SS]: " + message
             for p in self.social_spies:
-                yield from send_message(p.connection,
-                                        ssmsg,
-                                        name=sssender,
-                                        mode=ChatReceiveMode.BROADCAST)
+                if p.logged_in:
+                    yield from send_message(p.connection,
+                                            ssmsg,
+                                            name=sssender,
+                                            mode=ChatReceiveMode.BROADCAST)
         else:
             yield from send_message(connection,
                                     "Couldn't find a player with name {}"
@@ -372,10 +376,11 @@ class ChatEnhancements(StorageCommandPlugin):
                                                   recipient.alias)
             ssmsg = "[SS]: " + message
             for p in self.social_spies:
-                yield from send_message(p.connection,
-                                        ssmsg,
-                                        name=sssender,
-                                        mode=ChatReceiveMode.BROADCAST)
+                if p.logged_in:
+                    yield from send_message(p.connection,
+                                            ssmsg,
+                                            name=sssender,
+                                            mode=ChatReceiveMode.BROADCAST)
         else:
             yield from send_message(connection,
                                     "You haven't been messaged by anyone.")

--- a/plugins/chat_manager.py
+++ b/plugins/chat_manager.py
@@ -88,14 +88,16 @@ class ChatManager(SimpleCommandPlugin):
             return
         elif player.priority >= connection.player.priority:
             send_message(connection,
-                         "{} is unmuteable.".format(player.alias))
+                         "Can't mute {}, they are equal or higher "
+                         "than your rank!".format(player.alias))
             return
         else:
             self.storage.mutes.add(player)
             send_message(connection,
                          "{} has been muted.".format(player.alias))
-            send_message(player.connection,
-                         "{} has muted you.".format(connection.player.alias))
+            if player.logged_in:
+                send_message(player.connection,
+                             "{} has muted you.".format(connection.player.alias))
 
     @Command("unmute",
              perm="chat_manager.mute",
@@ -123,5 +125,6 @@ class ChatManager(SimpleCommandPlugin):
             self.storage.mutes.remove(player)
             send_message(connection,
                          "{} has been unmuted.".format(player.alias))
-            send_message(player.connection,
-                         "{} has unmuted you.".format(connection.player.alias))
+            if player.logged_in:
+                send_message(player.connection,
+                             "{} has unmuted you.".format(connection.player.alias))

--- a/plugins/claims.py
+++ b/plugins/claims.py
@@ -255,8 +255,12 @@ class Claims(StorageCommandPlugin):
         else:
             protection = self.planet_protect.get_protection(location)
             uuids = protection.get_builders()
-            players = ", ".join([self.plugins['player_manager']
-                                .get_player_by_uuid(x).alias for x in uuids])
+            aliases = []
+            for uid in uuids:
+                plr = self.plugins["player_manager"].get_player_by_uuid(uid)
+                if plr:
+                    aliases.append(plr.alias)
+            aliases = ", ".join(aliases)
             send_message(connection,
                          "Players allowed to build at location '{}': {}"
                          "".format(connection.player.location, players))

--- a/plugins/claims.py
+++ b/plugins/claims.py
@@ -263,7 +263,7 @@ class Claims(StorageCommandPlugin):
             aliases = ", ".join(aliases)
             send_message(connection,
                          "Players allowed to build at location '{}': {}"
-                         "".format(connection.player.location, players))
+                         "".format(connection.player.location, aliases))
 
     @Command("change_owner",
              perm="claims.manage_claims",

--- a/plugins/planet_protect.py
+++ b/plugins/planet_protect.py
@@ -371,8 +371,9 @@ class PlanetProtect(StorageCommandPlugin):
             uuids = protection.get_builders()
             aliases = []
             for uid in uuids:
-                aliases.append(self.plugins['player_manager']
-                               .get_player_by_uuid(uid).alias)
+                plr = self.plugins['player_manager'].get_player_by_uuid(uid)
+                if plr:
+                    aliases.append(plr.alias)
             aliases = ", ".join(aliases)
             send_message(connection,
                          "Players allowed to build at location '{}': {}"

--- a/plugins/player_manager.py
+++ b/plugins/player_manager.py
@@ -832,19 +832,12 @@ class PlayerManager(SimpleCommandPlugin):
         :param uuid: Target player to look up
         :return: Ship object.
         """
-        def _get_player_name(uid):
-            player = ""
-            if isinstance(uid, bytes):
-                uid = uid.decode("utf-8")
-            for p in self.factory.connections:
-                if p.player.uuid == uid:
-                    player = p.player.alias
-                    return player
 
         if uuid in self.shelf["ships"]:
             return self.shelf["ships"][uuid]
         else:
-            ship = Ship(uuid, _get_player_name(uuid))
+            name = self.get_player_by_uuid(uuid).alias
+            ship = Ship(uuid, name)
             self.shelf["ships"][uuid] = ship
             return ship
 


### PR DESCRIPTION
Changes:
Player Manager: Fix AttributeError in _add_or_get_ship
Planet Protect: Fix AttributeError in /list_builders
Claims: Fix AttributeErrors in /list_builders
Chat Enhancements: Fix AttributeErrors relating to social spy
Chat Manager: Fix AttributeErrors in /mute, /unmute
General Commands: Add mute/ban status to /whois
All of these are relating to player objects without connections. I'm guessing these have started surfacing much more often due to 1.3's unfortunate habit of frequently disconnecting everyone.