### PR TITLE
Timed saves for player database, misc. bug fixes.

### DIFF
--- a/config/permissions.json.default
+++ b/config/permissions.json.default
@@ -58,6 +58,7 @@
       "player_manager.kick",
       "player_manager.ban",
       "player_manager.user",
+      "player_manager.save",
       "privileged_chatter.modchat"
     ]
   },

--- a/plugins/claims.py
+++ b/plugins/claims.py
@@ -432,46 +432,40 @@ class Claims(StorageCommandPlugin):
                 send_message(connection, "Lists players on the access list.")
                 send_message(connection, "/planet_access help")
                 send_message(connection, "Displays this help.")
-            else:
-                target = self.plugins.player_manager.find_player(" ".join(data[0:-1]))
-                if not target:
-                    send_message(connection, "Argument not recognized. "
-                                             "See /planet_access help "
-                                             "for usage.")
-                if data[-1] == "add":
-                    if target.uuid not in access["list"]:
-                        if not access["whitelist"] and target == \
-                                connection.player:
-                            send_message(connection, "Can't add yourself to "
-                                                     "the blacklist!")
-                        else:
-                            access["list"].append(target.uuid)
-                            send_message(connection, "{} is now {} access to "
-                                                     "this planet"
-                                         .format(target.alias, allow))
+            elif data[0].lower() == "add":
+                target = self.plugins.player_manager.find_player(" ".join(data[1:]))
+                if target.uuid not in access["list"]:
+                    if not access["whitelist"] and target == \
+                            connection.player:
+                        send_message(connection, "Can't add yourself to "
+                                                 "the blacklist!")
                     else:
-                        send_message(connection, "{} is already {} access to "
-                                                 "this planet."
-                                     .format(target.alias, allow))
-                elif data[-1] == "remove":
-                    if target.uuid in access["list"]:
-                        if access["whitelist"] and target == connection.player:
-                            send_message(connection, "Can't remove yourself "
-                                                     "from the whitelist!")
-                        else:
-                            access["list"].remove(target.uuid)
-                            send_message(connection, "{} has been removed "
-                                                     "from the {} list"
-                                                     " for this planet."
-                                         .format(target.alias, allow))
-                    else:
-                        send_message(connection, "{} is not on the {} list "
-                                                 "for this planet."
+                        access["list"].append(target.uuid)
+                        send_message(connection, "{} is now {} access to "
+                                                 "this planet"
                                      .format(target.alias, allow))
                 else:
-                    send_message(connection, "Argument not recognized. "
-                                             "Usage: /planet_access [name] "
-                                             "add/remove")
+                    send_message(connection, "{} is already {} access to "
+                                             "this planet."
+                                 .format(target.alias, allow))
+            elif data[0].lower() == "remove":
+                target = self.plugins.player_manager.find_player(" ".join(data[1:]))
+                if target.uuid in access["list"]:
+                    if access["whitelist"] and target == connection.player:
+                        send_message(connection, "Can't remove yourself from "
+                                                 "the whitelist!")
+                    else:
+                        access["list"].remove(target.uuid)
+                        send_message(connection, "{} has been removed from "
+                                                 "the {} list for this planet."
+                                     .format(target.alias, allow))
+                else:
+                    send_message(connection, "{} is not on the {} list for "
+                                             "this planet."
+                                 .format(target.alias, allow))
+            else:
+                send_message(connection, "Argument not recognized. See "
+                                         "/planet_access help for usage.")
     @Command("purge_claims",
              perm="claims.purge_claims",
              doc="Purge the claims of the target player, if something "

--- a/plugins/discord_bot.py
+++ b/plugins/discord_bot.py
@@ -108,7 +108,7 @@ class DiscordPlugin(BasePlugin, discord.Client):
                                  'ban', 'unban', 'kick', 'list_bans', 'mute',
                                  'unmute', 'set_motd', 'whois', 'broadcast',
                                  'user', 'del_player', 'maintenance_mode',
-                                 'shutdown')
+                                 'shutdown', 'save')
 
     def activate(self):
         BasePlugin.activate(self)
@@ -240,8 +240,8 @@ class DiscordPlugin(BasePlugin, discord.Client):
         if message.author.id != self.client_id:
             if message.content[0] == self.command_prefix:
                 self.command_target = message.channel
-                asyncio.ensure_future(self.handle_command(message.content[
-                                                          1:], message.author))
+                asyncio.ensure_future(self.handle_command(message.content[1:],
+                                                          message.author))
             elif message.channel == self.channel:
                 for emote in server.emojis:
                     text = text.replace("<:{}:{}>".format(emote.name,

--- a/plugins/general_commands.py
+++ b/plugins/general_commands.py
@@ -16,7 +16,7 @@ import packets
 import pparser
 import data_parser
 from base_plugin import SimpleCommandPlugin
-from utilities import send_message, Command, broadcast, link_plugin_if_available
+from utilities import send_message, Command, broadcast, link_plugin_if_available, State
 
 
 ###
@@ -318,7 +318,6 @@ class GeneralCommands(SimpleCommandPlugin):
         shutdown_time = 5
         if data:
             if data[0].isdigit():
-                self.logger.debug("We think it is an int, lets use it.")
                 shutdown_time = int(data[0])
 
         broadcast(self, "^red;(ADMIN) The server is shutting down in {} "
@@ -327,6 +326,7 @@ class GeneralCommands(SimpleCommandPlugin):
         # this is a noisy shutdown (makes a bit of errors in the logs). Not
         # sure how to make it better...
         self.logger.warning("Shutting down server now.")
+        self.plugins.player_manager.sync()
         sys.exit()
 
     @Command("maintenance_mode",

--- a/plugins/irc_bot.py
+++ b/plugins/irc_bot.py
@@ -138,7 +138,7 @@ class IRCPlugin(BasePlugin):
                                  'ban', 'unban', 'kick', 'list_bans', 'mute',
                                  'unmute', 'set_motd', 'whois', 'broadcast',
                                  'user', 'del_player', 'maintenance_mode',
-                                 'shutdown')
+                                 'shutdown', 'save')
     def activate(self):
         super().activate()
         self.dispatcher = self.plugins.command_dispatcher

--- a/plugins/player_manager.py
+++ b/plugins/player_manager.py
@@ -109,6 +109,7 @@ class Player:
         """
         self.permissions = set()
         highest_rank = None
+        self.ranks = {x.lower() for x in self.ranks}
         for r in self.ranks:
             if not highest_rank:
                 highest_rank = r
@@ -576,7 +577,7 @@ class PlayerManager(SimpleCommandPlugin):
             config['permissions'] = set(config['permissions'])
             if 'inherits' in config:
                 config['permissions'] |= build_inherits(config['inherits'])
-            final[rank] = config
+            final[rank.lower()] = config
 
         return final
 
@@ -1147,64 +1148,66 @@ class PlayerManager(SimpleCommandPlugin):
         elif data[0].lower() == "addrank":
             target = self.find_player(data[1])
             if target:
-                if not data[2]:
+                search = data[2].lower()
+                if not search:
                     send_message(connection, "No rank specified.")
                     return
-                if data[2] not in self.ranks:
+                if search not in self.ranks:
                     send_message(connection, "Rank {} does not exist."
                                  .format(data[2]))
                     return
-                rank = self.ranks[data[2]]
+                rank = self.ranks[search]
                 if rank["priority"] >= connection.player.priority:
                     yield from send_message(connection, "You don't have "
                                             "permission to do that!")
-                elif data[2] in target.ranks:
+                elif search in target.ranks:
                     yield from send_message(connection, "Player {} already "
                                                         "has rank {}."
-                                            .format(target.alias, data[2]))
+                                            .format(target.alias, search))
                 else:
-                    target.ranks.add(data[2])
+                    target.ranks.add(search)
                     target.update_ranks(self.ranks)
                     if target.logged_in:
                         yield from send_message(target.connection,
                                                 "You were granted rank {} by {}."
-                                                .format(data[2],
+                                                .format(search,
                                                         connection.player.alias))
                     yield from send_message(connection, "Granted rank "
                                                         "{} to {}."
-                                            .format(data[2], target.alias))
+                                            .format(search, target.alias))
             else:
                 yield from send_message(connection, "User {} not "
                                                     "found.".format(data[1]))
         elif data[0].lower() == "rmrank":
             target = self.find_player(data[1])
             if target:
-                if not data[2]:
+                search = data[2].lower()
+                if not search:
                     send_message(connection, "No rank specified.")
                     return
-                if data[2] not in self.ranks:
+                if search not in self.ranks:
                     send_message(connection, "Rank {} does not exist."
                                  .format(data[2]))
                     return
                 if target.priority >= connection.player.priority:
                     yield from send_message(connection, "You don't have "
                                             "permission to do that!")
-                elif data[2] not in target.ranks:
+                elif search not in target.ranks:
                     yield from send_message(connection, "Player {} does not "
                                                         "have rank {}."
-                                            .format(target.alias, data[2]))
+                                            .format(target.alias, search))
                 else:
-                    target.ranks.remove(data[2])
+                    target.ranks.remove(search)
                     target.update_ranks(self.ranks)
                     if target.logged_in:
                         yield from send_message(target.connection, "{} removed"
                                                                    " rank {} "
                                                                    "from you."
                                                 .format(connection.player.alias,
-                                                        data[2]))
+                                                        search))
                     yield from send_message(connection, "Removed rank "
                                                         "{} from {}."
-                                            .format(data[2], target.alias))
+                                            .format(search, target.alias))
             else:
                 yield from send_message(connection, "User {} not "
                                                     "found.".format(data[1]))
@@ -1221,7 +1224,7 @@ class PlayerManager(SimpleCommandPlugin):
         elif data[0].lower() == "listranks":
             target = self.find_player(data[1])
             if target:
-                ranks = ", ".join(target.ranks)
+                ranks = ", ".join((x.capitalize() for x in target.ranks))
                 yield from send_message(connection, "Ranks for user {}:"
                                                     "\n{}"
                                         .format(target.alias, ranks))

--- a/plugins/player_manager.py
+++ b/plugins/player_manager.py
@@ -694,6 +694,9 @@ class PlayerManager(SimpleCommandPlugin):
         :param uuid: String: UUID of player to check.
         :return: Mixed: Player object.
         """
+        # Sometimes UUID is given as bytes by mistake
+        if isinstance(uuid, bytes):
+            uuid = uuid.encode('utf-8')
         if uuid in self.shelf["players"]:
             return self.shelf["players"][uuid]
 

--- a/plugins/player_manager.py
+++ b/plugins/player_manager.py
@@ -834,7 +834,8 @@ class PlayerManager(SimpleCommandPlugin):
             if p.name != name:
                 p.name = name
                 alias = self.clean_name(name)
-                if self.get_player_by_alias(alias) or alias is None:
+                if alias != p.alias and (self.get_player_by_alias(alias)
+                                         or alias is None):
                     alias = uuid[0:4]
                 p.alias = alias
             p.update_ranks(self.ranks)


### PR DESCRIPTION
Changes:
Player Manager: Player database now saves on a timer (configurable interval) and can be manually saved with /save.
Player Manager: Kick player if banned while online
Player Manager: Handles `bytes` UUIDs being passed to get_player_by_uuid
Player Manager: Fix edge-case issue with name filtering
Player Manager: Case-desensitize ranks
Claims: Re-order /planet_access arguments