### PR TITLE
Re-implement species whitelist.

### DIFF
--- a/config/config.json.default
+++ b/config/config.json.default
@@ -64,16 +64,6 @@
         "planet_backups": {},
         "planet_protect": {},
         "player_manager": {
-            "allowed_species": [
-                "apex",
-                "avian",
-                "glitch",
-                "floran",
-                "human",
-                "hylotl",
-                "penguin",
-                "novakid"
-            ],
             "new_user_ranks": [
                 "Guest"
             ],
@@ -91,6 +81,19 @@
         },
         "simple_command_plugin": {},
         "spawn": {},
+        "species_whitelist": {
+            "enabled": false,
+            "allowed_species": [
+                "apex",
+                "avian",
+                "glitch",
+                "floran",
+                "human",
+                "hylotl",
+                "penguin",
+                "novakid"
+            ]
+        },
         "storage_command_plugin": {},
         "warp_plugin": {}
     },

--- a/plugins/species_whitelist.py
+++ b/plugins/species_whitelist.py
@@ -1,0 +1,56 @@
+"""
+StarryPy species whitelist plugin
+
+Prevents players with unknown species from joining the server.
+This is necessary due to a year+ old "bug" detailed here:
+https://community.playstarbound.com/threads/119569/
+
+Original Authors: GermaniumSystem
+"""
+
+from base_plugin import BasePlugin
+from data_parser import ConnectFailure
+from packets import packets
+from pparser import build_packet
+
+
+
+class SpeciesWhitelist(BasePlugin):
+    name = "species_whitelist"
+    depends = ["player_manager"]
+    default_config = {"enabled": False,
+                      "allowed_species": [
+                          "apex",
+                          "avian",
+                          "glitch",
+                          "floran",
+                          "human",
+                          "hylotl",
+                          "penguin",
+                          "novakid"
+                      ]}
+
+
+    def activate(self):
+        super().activate()
+        self.enabled = self.config.get_plugin_config(self.name)["enabled"]
+        self.allowed_species = self.config.get_plugin_config(self.name)["allowed_species"]
+
+
+    def on_client_connect(self, data, connection):
+        if not self.enabled:
+            return True
+        species = data['parsed']['species']
+        if species not in self.allowed_species:
+            self.logger.warn("Aborting connection - player's species ({}) "
+                    "is not in whitelist.".format(species))
+            rejection_packet = build_packet(packets['connect_failure'],
+                    ConnectFailure.build(dict(reason="^red;Connection "
+                            "aborted!\n\n^orange;Your species ({}) is not "
+                            "allowed on this server.\n^green;Please use a "
+                            "different character.".format(species))))
+            yield from connection.raw_write(rejection_packet)
+            connection.die()
+            return False
+        return True
+


### PR DESCRIPTION
Re #120: The species whitelisting feature was mistakenly removed and should be re-implemented. This has been done via a new plugin, which is disabled by default.