### PR TITLE
change to use discord.py latest to 1.7.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.5-stretch
 
-RUN pip install discord irc3
+RUN pip install discord==1.7.3 irc3
 
 RUN mkdir /app /app/defaults
 COPY . /app/


### PR DESCRIPTION
discord.py no longer supports Python 3.5 in versions 2.0.0 and above. Therefore, I have modified this file to use discord.py==1.7.3, the last version that supports Python 3.5, instead of the latest version. When executing this file, it will now utilize discord.py==1.7.3