### PR TITLE
OpenSB Support - register filters always, use flags to control compression loop

### DIFF
--- a/server.py
+++ b/server.py
@@ -48,7 +48,6 @@ class StarryPyServer:
         self._client_read_future = None
         self._server_write_future = None
         self._client_write_future = None
-        self._expect_server_loop_death = False
         logger.info("Received connection from {}".format(self.client_ip))
 
     def start_zstd(self):
@@ -92,12 +91,8 @@ class StarryPyServer:
                          "{}: {}".format(err.__class__.__name__, err))
             logger.error("Error details and traceback: {}".format(traceback.format_exc()))
         finally:
-            if not self._expect_server_loop_death:
-                logger.info("Server loop ended.")
-                self.die()
-            else:
-                logger.info("Restarting server loop for switch to zstd.")
-                self._expect_server_loop_death = False
+            logger.info("Server loop ended.")
+            self.die()
 
     async def client_loop(self):
         """

--- a/server.py
+++ b/server.py
@@ -33,8 +33,8 @@ class StarryPyServer:
     """
     def __init__(self, reader, writer, config, factory):
         logger.debug("Initializing connection.")
-        self._reader = reader # read packets from client
-        self._writer = writer # writes packets to client
+        self._reader = ZstdFrameReader(reader, Direction.TO_SERVER) # read packets from client
+        self._writer = ZstdFrameWriter(writer) # writes packets to client
         self._client_reader = None # read packets from server (acting as client)
         self._client_writer = None # write packets to server
         self.factory = factory
@@ -52,13 +52,10 @@ class StarryPyServer:
         logger.info("Received connection from {}".format(self.client_ip))
 
     def start_zstd(self):
-        self._reader = ZstdFrameReader(self._reader, Direction.TO_SERVER)
-        self._client_reader= ZstdFrameReader(self._client_reader, Direction.TO_CLIENT)
-        self._writer = ZstdFrameWriter(self._writer, skip_packets=1)
-        self._client_writer = ZstdFrameWriter(self._client_writer)
-        self._expect_server_loop_death = True
-        self._server_loop_future.cancel()
-        self._server_loop_future = asyncio.create_task(self.server_loop())
+        self._reader.enable_zstd()
+        self._client_reader.enable_zstd()
+        self._writer.enable_zstd(skip_packets=1) # skip this packet
+        self._client_writer.enable_zstd()
         logger.info("Switched to zstd")
 
 
@@ -109,9 +106,11 @@ class StarryPyServer:
 
         :return:
         """
-        (self._client_reader, self._client_writer) = \
-            await asyncio.open_connection(self.config['upstream_host'],
+        (reader, writer) = await asyncio.open_connection(self.config['upstream_host'],
                                                self.config['upstream_port'])
+        
+        self._client_reader = ZstdFrameReader(reader, Direction.TO_CLIENT)
+        self._client_writer = ZstdFrameWriter(writer)
 
         try:
             while True:

--- a/zstd_writer.py
+++ b/zstd_writer.py
@@ -3,9 +3,14 @@ from io import BufferedReader, BytesIO
 import zstandard as zstd
 
 class ZstdFrameWriter:
-    def __init__(self, raw_writer: asyncio.StreamWriter, skip_packets=0):
+    def __init__(self, raw_writer: asyncio.StreamWriter):
         self.compressor = zstd.ZstdCompressor()
         self.raw_writer = raw_writer
+        self.skip_packets = 0
+        self.zstd_enabled = False
+    
+    def enable_zstd(self, skip_packets=0):
+        self.zstd_enabled = True
         self.skip_packets = skip_packets
 
     async def drain(self):
@@ -16,6 +21,10 @@ class ZstdFrameWriter:
         self.compressor = None
 
     def write(self, data):
+        
+        if not self.zstd_enabled:
+            self.raw_writer.write(data)
+            return
 
         if self.skip_packets > 0:
             self.skip_packets -= 1


### PR DESCRIPTION
Per discussion with @rubellyte on #156, this PR builds on that one and hooks up the zstd filters for all connections, but disables the compressor/decompressor by default.  When protocol packets are detected indicating zstd support, the filters start compressing and decompressing without need to restart the main server loop.  I have tested this briefly with an OSB client and server running the latest version (0.1.6) with no issue, but I have not tested vanilla client/server yet.